### PR TITLE
force go_import_path to enable travis-ci for forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 services:
 - docker
 language: go
+go_import_path: github.com/terraform-providers/terraform-provider-spotinst
 go:
 - 1.9.1
 


### PR DESCRIPTION
This setting allows any fork to run successful builds on travis-ci