### PR TITLE
Fixing error output for roll failures

### DIFF
--- a/spotinst/resource_spotinst_elastigroup_aws.go
+++ b/spotinst/resource_spotinst_elastigroup_aws.go
@@ -359,7 +359,7 @@ func rollGroup(resourceData *schema.ResourceData, meta interface{}) error {
 
 							if err != nil {
 
-								// checks whether to retry role
+								// checks whether to retry roll
 								if errs, ok := err.(client.Errors); ok && len(errs) > 0 {
 									for _, err := range errs {
 										if strings.Contains(err.Code, "CANT_ROLL_CAPACITY_BELOW_MINIMUM") {
@@ -374,7 +374,7 @@ func rollGroup(resourceData *schema.ResourceData, meta interface{}) error {
 
 							awaitErr := awaitReadyRoll(groupId, rollConfig, rollOut, meta.(*Client))
 							if awaitErr != nil {
-								waitErr := fmt.Errorf("[ERROR] Timed out when waiting for minimum roll %%: %s", err)
+								waitErr := fmt.Errorf("[ERROR] Timed out when waiting for minimum roll %%: %s", awaitErr)
 								return resource.NonRetryableError(waitErr)
 							} else {
 								log.Printf("onRoll() -> Successfully rolled group [%v]", groupId)


### PR DESCRIPTION
I noticed when we hit a timeout in our AWS rolls, we end up with an empty error, looks like this:
`Error: [ERROR] Timed out when waiting for minimum roll %: %!s(<nil>)`

That error should be populated if this error is triggered, I noticed this is just due to passing the wrong error output to the `fmt.Errorf()` call. So this fixes that.

It also fixes a typo between `role` and `roll`