### PR TITLE
fixed deployment_preferences and strategy blocks to not have equal sign

### DIFF
--- a/website/docs/r/elastigroup_aws_beanstalk.html.markdown
+++ b/website/docs/r/elastigroup_aws_beanstalk.html.markdown
@@ -27,11 +27,11 @@ resource "spotinst_elastigroup_aws_beanstalk" "elastigoup-aws-beanstalk" {
  beanstalk_environment_id   = "e-example"
  instance_types_spot        = ["t2.micro", "t2.medium", "t2.large"]
 
- deployment_preferences = {
+ deployment_preferences {
   automatic_roll        = true
   batch_size_percentage = 100
   grace_period          = 90
-    strategy = {
+    strategy {
       action                 = "REPLACE_SERVER"
       should_drain_instances = true
     }


### PR DESCRIPTION
it doesnt work with equal sign, because these are blocks and shouldn't have = sign