### PR TITLE
ForceNew in ocean_gke_launch_spec_import

### DIFF
--- a/spotinst/ocean_gke_launch_spec_import/fields_spotinst_ocean_gke_launch_spec_import.go
+++ b/spotinst/ocean_gke_launch_spec_import/fields_spotinst_ocean_gke_launch_spec_import.go
@@ -18,6 +18,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		&schema.Schema{
 			Type:     schema.TypeString,
 			Required: true,
+			ForceNew: true,
 		},
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			return nil
@@ -39,6 +40,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		&schema.Schema{
 			Type:     schema.TypeString,
 			Required: true,
+			ForceNew: true,
 		},
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			return nil


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-spotinst/issues/90

The recommendation from Spot is to not delete your node pools after creating the launch spec import referencing them. For that reason, we should force create new on this launch spec so that it's replaced when the referenced node pool (or ocean id) changes