### PR TITLE
Fixed reference to autoscale_is_auto_config

### DIFF
--- a/website/docs/r/ocean_aws.html.markdown
+++ b/website/docs/r/ocean_aws.html.markdown
@@ -101,7 +101,7 @@ The following arguments are supported:
 * `autoscale_is_enabled` - (Optional, Default: `true`) Enable the Ocean Kubernetes autoscaler.
 * `autoscale_is_auto_config` - (Optional, Default: `true`) Automatically configure and optimize headroom resources.
 * `autoscale_cooldown` - (Optional, Default: `null`) Cooldown period between scaling actions.
-* `auto_headroom_percentage` - (Optional) Set the auto headroom percentage (a number in the range [0, 200]) which controls the percentage of headroom from the cluster. Relevant only when `isAutoConfig` toggled on.
+* `auto_headroom_percentage` - (Optional) Set the auto headroom percentage (a number in the range [0, 200]) which controls the percentage of headroom from the cluster. Relevant only when `autoscale_is_auto_config` toggled on.
 * `autoscale_headroom` - (Optional) Spare resource capacity management enabling fast assignment of Pods without waiting for new resources to launch.
 * `cpu_per_unit` - (Optional) Optionally configure the number of CPUs to allocate the headroom. CPUs are denoted in millicores, where 1000 millicores = 1 vCPU.
 * `gpu_per_unit` - (Optional) Optionally configure the number of GPUS to allocate the headroom.


### PR DESCRIPTION
Reference should use snake casing, not camel casing. The `isAutoConfig` didn't refer to a valid Terraform attribute name.