### PR TITLE
Merge 'develop_v0.12' into 'release_v0.12'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 * resource/ocean_aws: resolved error with `spot_percentage` not applying 0 as value 
+* resource/ocean_gke_launch_spec_import: `OceanId` and `NodePoolName` are now flagged with ForceNew
 
 ## 1.23.0 (August 11, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.24.0 (Unreleased)
+
+BUG FIXES:
+* resource/ocean_aws: resolved error with `spot_percentage` not applying 0 as value 
+
 ## 1.23.0 (August 11, 2020)
 
 ENHANCEMENTS:

--- a/spotinst/ocean_aws_strategy/fields_spotinst_ocean_aws_strategy.go
+++ b/spotinst/ocean_aws_strategy/fields_spotinst_ocean_aws_strategy.go
@@ -133,20 +133,17 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			clusterWrapper := resourceObject.(*commons.AWSClusterWrapper)
 			cluster := clusterWrapper.GetCluster()
-			if v, ok := resourceData.GetOk(string(SpotPercentage)); ok {
-				spotPct := v.(float64)
-				cluster.Strategy.SetSpotPercentage(spotinst.Float64(spotPct))
+			if v, ok := resourceData.Get(string(SpotPercentage)).(float64); ok {
+				cluster.Strategy.SetSpotPercentage(spotinst.Float64(v))
 			}
 			return nil
 		},
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			clusterWrapper := resourceObject.(*commons.AWSClusterWrapper)
 			cluster := clusterWrapper.GetCluster()
-			var spotPct *float64 = nil
-			if v, ok := resourceData.GetOk(string(SpotPercentage)); ok {
-				spotPct = spotinst.Float64(v.(float64))
+			if v, ok := resourceData.Get(string(SpotPercentage)).(float64); ok {
+				cluster.Strategy.SetSpotPercentage(spotinst.Float64(v))
 			}
-			cluster.Strategy.SetSpotPercentage(spotPct)
 			return nil
 		},
 		nil,

--- a/spotinst/ocean_gke_launch_spec_import/fields_spotinst_ocean_gke_launch_spec_import.go
+++ b/spotinst/ocean_gke_launch_spec_import/fields_spotinst_ocean_gke_launch_spec_import.go
@@ -18,6 +18,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		&schema.Schema{
 			Type:     schema.TypeString,
 			Required: true,
+			ForceNew: true,
 		},
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			return nil
@@ -39,6 +40,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		&schema.Schema{
 			Type:     schema.TypeString,
 			Required: true,
+			ForceNew: true,
 		},
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			return nil

--- a/spotinst/resource_spotinst_ocean_gke_launch_spec_import.go
+++ b/spotinst/resource_spotinst_ocean_gke_launch_spec_import.go
@@ -21,7 +21,7 @@ func resourceSpotinstOceanGKELaunchSpecImport() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceSpotinstOceanGKELaunchSpecImportCreate,
 		Read:   resourceSpotinstOceanGKELaunchSpecImportRead,
-		Update: resourceSpotinstOceanGKELaunchSpecImportUpdate,
+		//Update: resourceSpotinstOceanGKELaunchSpecImportUpdate,
 		Delete: resourceSpotinstOceanGKELaunchSpecImportDelete,
 
 		Importer: &schema.ResourceImporter{

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,7 @@ var (
 	// Version represents the main version number.
 	//
 	// Read-only.
-	Version = "1.23.0"
+	Version = "1.24.0"
 
 	// Prerelease represents an optional pre-release label for the version.
 	// If this is "" (empty string) then it means that it is a final release.


### PR DESCRIPTION
fixed: in ocean_aws the spot_percentage field not being populated 
when parameter is set to 0
fixed: Removed update function in resource_spotinst_ocean_gke_launch_spec_import.go 
due to addition of force new to ALL fields in fields_spotinst_ocean_gke_launch_spec_import.go
relates to- https://github.com/terraform-providers/terraform-provider-spotinst/pull/91/files
updated: version and changelog