### PR TITLE
fix(ocean/gke): Allow users to override controller cluster ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ENHANCEMENTS:
 * resource/spotinst_ocean_ecs_launch_specification: added `block_device_mappings`
+* resource/spotinst_ocean_gke_import: added `controller_cluster_id`
+
+DEPRECATIONS:
+* resource/spotinst_ocean_gke_import: deprecated `cluster_controller_id`
 
 ## 1.27.0 (October 28, 2020)
 
 ENHANCEMENTS:
 * resource/spotinst_ocean_aws_launch_spec: added `spot_percentage` under `strategy`
 * resource/spotinst_elastigroup_aws_launch_configuration: added `metadata_options`.
-
 
 ## 1.26.0 (October 27, 2020)
 

--- a/spotinst/ocean_gke_import/consts.go
+++ b/spotinst/ocean_gke_import/consts.go
@@ -16,5 +16,8 @@ const (
 	MaxSize             commons.FieldName = "max_size"
 	MinSize             commons.FieldName = "min_size"
 	DesiredCapacity     commons.FieldName = "desired_capacity"
+	ControllerClusterID commons.FieldName = "controller_cluster_id"
+
+	// Deprecated: Please use ControllerClusterID instead.
 	ClusterControllerID commons.FieldName = "cluster_controller_id"
 )

--- a/spotinst/ocean_gke_import/fields_spotinst_ocean_gke_import.go
+++ b/spotinst/ocean_gke_import/fields_spotinst_ocean_gke_import.go
@@ -325,6 +325,34 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		nil,
 		nil,
 	)
+
+	fieldsMap[ControllerClusterID] = commons.NewGenericField(
+		commons.OceanGKEImport,
+		ControllerClusterID,
+		&schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.GKEImportClusterWrapper)
+			cluster := clusterWrapper.GetCluster()
+			if err := resourceData.Set(string(ControllerClusterID), spotinst.StringValue(cluster.ControllerClusterID)); err != nil {
+				return fmt.Errorf(commons.FailureFieldReadPattern, string(ControllerClusterID), err)
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.GKEImportClusterWrapper)
+			cluster := clusterWrapper.GetCluster()
+			if v, ok := resourceData.GetOk(string(ControllerClusterID)); ok {
+				cluster.SetControllerClusterId(spotinst.String(v.(string)))
+			}
+			return nil
+		},
+		nil,
+		nil,
+	)
 }
 
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/spotinst/resource_spotinst_ocean_gke_import.go
+++ b/spotinst/resource_spotinst_ocean_gke_import.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/spotinst/terraform-provider-spotinst/spotinst/ocean_gke_import_autoscaler"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/spotinst/spotinst-sdk-go/service/ocean/providers/gcp"
@@ -15,6 +13,7 @@ import (
 	"github.com/spotinst/spotinst-sdk-go/spotinst/client"
 	"github.com/spotinst/terraform-provider-spotinst/spotinst/commons"
 	"github.com/spotinst/terraform-provider-spotinst/spotinst/ocean_gke_import"
+	"github.com/spotinst/terraform-provider-spotinst/spotinst/ocean_gke_import_autoscaler"
 	"github.com/spotinst/terraform-provider-spotinst/spotinst/ocean_gke_import_scheduling"
 )
 
@@ -165,8 +164,13 @@ func resourceSpotinstClusterGKEImportRead(resourceData *schema.ResourceData, met
 
 	// Expose the controller cluster identifier.
 	if clusterResponse.ControllerClusterID != nil {
-		if err := resourceData.Set("cluster_controller_id", *clusterResponse.ControllerClusterID); err != nil {
-			log.Printf("[ERROR] Failed to set cluster_controller_id")
+		for _, key := range []commons.FieldName{
+			ocean_gke_import.ControllerClusterID,
+			ocean_gke_import.ClusterControllerID, // maintains backward compatibility
+		} {
+			if err := resourceData.Set(string(key), *clusterResponse.ControllerClusterID); err != nil {
+				log.Printf("[ERROR] Failed to set %q", string(key))
+			}
 		}
 	}
 


### PR DESCRIPTION
```hcl
resource "spotinst_ocean_gke_import" "this" {
  depends_on = [module.gke]

  ...
  controller_cluster_id = local.controller_cluster_id
}
```