### PR TITLE
Set additional replica security groups

### DIFF
--- a/spotinst/mrscaler_aws/fields_spotinst_mrscaler_aws.go
+++ b/spotinst/mrscaler_aws/fields_spotinst_mrscaler_aws.go
@@ -823,7 +823,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			mrsWrapper := resourceObject.(*commons.MRScalerAWSWrapper)
 			scaler := mrsWrapper.GetMRScalerAWS()
-			if value, ok := resourceData.GetOk(string(AddlPrimarySecurityGroups)); ok {
+			if value, ok := resourceData.GetOk(string(AddlReplicaSecurityGroups)); ok {
 				if groups, err := expandGenericList(value); err != nil {
 					return err
 				} else {


### PR DESCRIPTION
Currently the **replica additional security group** is set to use the parameter `additional_primary_security_groups`
it should uses `additional_replica_security_groups`