### PR TITLE
fix(elastigroup/aws): retry creation for "cant_create_group" errors

### DIFF
--- a/spotinst/resource_spotinst_elastigroup_aws.go
+++ b/spotinst/resource_spotinst_elastigroup_aws.go
@@ -224,6 +224,10 @@ func createGroup(resourceData *schema.ResourceData, group *aws.Group, spotinstCl
 						strings.Contains(err.Message, "Invalid IAM Instance Profile") {
 						return resource.RetryableError(err)
 					}
+
+					if err.Code == "CANT_CREATE_GROUP" && strings.Contains(err.Message, "Failed to create group") {
+						return resource.RetryableError(err)
+					}
 				}
 			}
 


### PR DESCRIPTION
We tend to many Elastigroup instances and according to the support staff we're running into AWS rate limits. We don't have much visibility into the rate limit, but it tends to manifest as this sort of error:
```
Error: [ERROR] failed to create group: POST https://api.spotinst.io/aws/ec2/group?accountId=[snip]: 400 (request: "[snip]") CANT_CREATE_GROUP: Failed to create group
```

If it's a AWS rate limit, seems it should be retryable.

Unsure if this is visible to the maintainers, but this is the support request for reference: https://support.spot.io/hc/en-us/requests/1405523.