### PR TITLE
fix(elastigroup/aws): retry creation for "cant_validate_image" errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## Unreleased
 
+BUG FIXES:
+* resource/spotinst_elastigroup_aws: retry creation for `cant_validate_image` errors
+
 ## 1.41.0 (April 28, 2021)
 
 BUG FIXES:
-* resource/spotinst_elastigroup_aws: retry creation for `cant_create_group` errors 
+* resource/spotinst_elastigroup_aws: retry creation for `cant_create_group` errors
 
 ## 1.40.0 (April 25, 2021)
 

--- a/spotinst/resource_spotinst_elastigroup_aws.go
+++ b/spotinst/resource_spotinst_elastigroup_aws.go
@@ -228,6 +228,10 @@ func createGroup(resourceData *schema.ResourceData, group *aws.Group, spotinstCl
 						strings.Contains(strings.ToLower(err.Message), "failed to create group") {
 						return resource.RetryableError(err)
 					}
+					if err.Code == "CANT_VALIDATE_IMAGE" &&
+						strings.Contains(strings.ToLower(err.Message), "can't validate ami") {
+						return resource.RetryableError(err)
+					}
 				}
 			}
 


### PR DESCRIPTION
One more similar to #184, thanks!