### PR TITLE
feat(ocean/aks): new field: `managed_service_identity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+ENHANCEMENTS:
+* resource/spotinst_ocean_aks: added support for `managed_service_identity` 
+
 ## 1.52.0 (July 7, 2021)
 
 ENHANCEMENTS:

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-docs v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
-	github.com/spotinst/spotinst-sdk-go v1.94.0
+	github.com/spotinst/spotinst-sdk-go v1.95.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 )

--- a/go.sum
+++ b/go.sum
@@ -363,6 +363,8 @@ github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spotinst/spotinst-sdk-go v1.94.0 h1:htEL2yAr6k/Cy4Bd+CxB07u+8YH9gWY5DrIXPs9R+M4=
 github.com/spotinst/spotinst-sdk-go v1.94.0/go.mod h1:RuKksd1/RyQogMCxKFI5B75NeFRcgl3W+26DVX6S4m0=
+github.com/spotinst/spotinst-sdk-go v1.95.0 h1:dgD8akCgeDhz/59CD4aIQT8DLz0x8nh33a0yN7jZjX4=
+github.com/spotinst/spotinst-sdk-go v1.95.0/go.mod h1:RuKksd1/RyQogMCxKFI5B75NeFRcgl3W+26DVX6S4m0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/spotinst/commons/common_ocean_aks.go
+++ b/spotinst/commons/common_ocean_aks.go
@@ -119,7 +119,8 @@ func NewAKSClusterWrapper() *AKSClusterWrapper {
 					Image: &azure.Image{
 						MarketplaceImage: &azure.MarketplaceImage{},
 					},
-					Extensions: []*azure.Extension{},
+					ManagedServiceIdentities: []*azure.ManagedServiceIdentity{},
+					Extensions:               []*azure.Extension{},
 					Network: &azure.Network{
 						NetworkInterfaces: []*azure.NetworkInterface{},
 					},

--- a/spotinst/ocean_aks_launch_specification/consts.go
+++ b/spotinst/ocean_aks_launch_specification/consts.go
@@ -8,6 +8,12 @@ const (
 )
 
 const (
+	ManagedServiceIdentity                  commons.FieldName = "managed_service_identity"
+	ManagedServiceIdentityResourceGroupName commons.FieldName = "resource_group_name"
+	ManagedServiceIdentityName              commons.FieldName = "name"
+)
+
+const (
 	Tag      commons.FieldName = "tag"
 	TagKey   commons.FieldName = "key"
 	TagValue commons.FieldName = "value"


### PR DESCRIPTION
This PR adds a new field (`managed_service_identity`) to `spotinst_ocean_aks` resource.