### PR TITLE
max_instances_count bug resolved in ocean_aws

### DIFF
--- a/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
+++ b/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
@@ -2017,7 +2017,7 @@ func expandResourceLimits(data interface{}) (*aws.ResourceLimits, error) {
 		if list != nil && list[0] != nil {
 			m := list[0].(map[string]interface{})
 
-			if v, ok := m[string(MaxInstanceCount)].(int); ok && v > 0 {
+			if v, ok := m[string(MaxInstanceCount)].(int); ok && v >= 0 {
 				resLimits.SetMaxInstanceCount(spotinst.Int(v))
 			} else {
 				resLimits.SetMaxInstanceCount(nil)


### PR DESCRIPTION
validation only allowd values > 0 therefore when 0 was entered, value was considered as NULL