### PR TITLE
Fixed resource_limits to support null

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
-	github.com/spotinst/spotinst-sdk-go v1.131.1
+	github.com/spotinst/spotinst-sdk-go v1.132.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 
 )

--- a/go.sum
+++ b/go.sum
@@ -352,8 +352,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.131.1 h1:8WGvAc1PKno221aSnzc42goFwgehHw7DKBWve437IyE=
-github.com/spotinst/spotinst-sdk-go v1.131.1/go.mod h1:C6mrT7+mqOgPyabacjyYTvilu8Xm96mvTvrZQhj99WI=
+github.com/spotinst/spotinst-sdk-go v1.132.0 h1:oQ9pZJTP6Z3NFjMhud0TuohSybc7V+qrzxrb9G82bI8=
+github.com/spotinst/spotinst-sdk-go v1.132.0/go.mod h1:C6mrT7+mqOgPyabacjyYTvilu8Xm96mvTvrZQhj99WI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
+++ b/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
@@ -549,7 +549,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		commons.OceanAWSLaunchConfiguration,
 		ResourceLimits,
 		&schema.Schema{
-			Type:     schema.TypeSet,
+			Type:     schema.TypeList,
 			Optional: true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
@@ -558,23 +558,11 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 						Type:     schema.TypeInt,
 						Optional: true,
 						Default:  -1,
-						DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-							if old == "-1" && new == "null" {
-								return true
-							}
-							return false
-						},
 					},
 					string(MinInstanceCount): {
 						Type:     schema.TypeInt,
 						Optional: true,
 						Default:  -1,
-						DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-							if old == "-1" && new == "null" {
-								return true
-							}
-							return false
-						},
 					},
 				},
 			},
@@ -1995,6 +1983,10 @@ func flattenResourceLimits(resourceLimits *aws.ResourceLimits) []interface{} {
 	if resourceLimits != nil {
 		result := make(map[string]interface{})
 
+		value := spotinst.Int(-1)
+		result[string(MinInstanceCount)] = value
+		result[string(MaxInstanceCount)] = value
+
 		if resourceLimits.MaxInstanceCount != nil {
 			result[string(MaxInstanceCount)] = spotinst.IntValue(resourceLimits.MaxInstanceCount)
 		}
@@ -2018,7 +2010,7 @@ func flattenTagSelector(tagSelector *aws.TagSelector) []interface{} {
 }
 
 func expandResourceLimits(data interface{}) (*aws.ResourceLimits, error) {
-	if list := data.(*schema.Set).List(); len(list) > 0 {
+	if list := data.([]interface{}); len(list) > 0 {
 		resLimits := &aws.ResourceLimits{}
 		if list != nil && list[0] != nil {
 			m := list[0].(map[string]interface{})

--- a/spotinst/ocean_gke_launch_spec/fields_spotinst_ocean_gke_launch_spec.go
+++ b/spotinst/ocean_gke_launch_spec/fields_spotinst_ocean_gke_launch_spec.go
@@ -992,7 +992,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		commons.OceanGKELaunchSpec,
 		ResourceLimits,
 		&schema.Schema{
-			Type:     schema.TypeSet,
+			Type:     schema.TypeList,
 			Optional: true,
 			MaxItems: 1,
 			Elem: &schema.Resource{
@@ -1283,7 +1283,7 @@ func expandStorage(data interface{}) (*gcp.Storage, error) {
 func expandResourceLimits(data interface{}) (*gcp.ResourceLimits, error) {
 	var resourceLimits *gcp.ResourceLimits
 	updated := 0
-	list := data.(*schema.Set).List()
+	list := data.([]interface{})
 	for _, v := range list {
 		attr, ok := v.(map[string]interface{})
 		if !ok {

--- a/spotinst/ocean_gke_launch_spec/fields_spotinst_ocean_gke_launch_spec.go
+++ b/spotinst/ocean_gke_launch_spec/fields_spotinst_ocean_gke_launch_spec.go
@@ -1000,10 +1000,12 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 					string(MaxInstanceCount): {
 						Type:     schema.TypeInt,
 						Optional: true,
+						Default:  -1,
 					},
 					string(MinInstanceCount): {
 						Type:     schema.TypeInt,
 						Optional: true,
+						Default:  -1,
 					},
 				},
 			},
@@ -1290,14 +1292,18 @@ func expandResourceLimits(data interface{}) (*gcp.ResourceLimits, error) {
 
 		r := &gcp.ResourceLimits{}
 
-		if v, ok := attr[string(MaxInstanceCount)].(int); ok {
+		if v, ok := attr[string(MaxInstanceCount)].(int); ok && v >= 0 {
 			updated = 1
 			r.SetMaxInstanceCount(spotinst.Int(v))
+		} else {
+			r.SetMaxInstanceCount(nil)
 		}
 
-		if v, ok := attr[string(MinInstanceCount)].(int); ok {
+		if v, ok := attr[string(MinInstanceCount)].(int); ok && v >= 0 {
 			updated = 1
 			r.SetMinInstanceCount(spotinst.Int(v))
+		} else {
+			r.SetMinInstanceCount(nil)
 		}
 
 		resourceLimits = r
@@ -1387,6 +1393,10 @@ func flattenResourceLimits(resourceLimits *gcp.ResourceLimits) []interface{} {
 
 	if resourceLimits != nil {
 		result := make(map[string]interface{})
+
+		value := spotinst.Int(-1)
+		result[string(MinInstanceCount)] = value
+		result[string(MaxInstanceCount)] = value
 
 		if resourceLimits.MaxInstanceCount != nil {
 			result[string(MaxInstanceCount)] = spotinst.IntValue(resourceLimits.MaxInstanceCount)


### PR DESCRIPTION
Fixed resource_limits to support null:
Now if don't pass max_instance_count or min_instance_count option will remain disable in VNG, earlier it was getting enabled with the default value set to 0.

Tested below mentioned scenarios:
1) Create min=nil, max=nil , Expected: it should not set value ---> Passed
2) Create min=nil , max=2 then check plan , Expected: it should show diff, then apply and it should update and reflect in UI --- Passed
3) Create min=0 , max=2 then check plan , Expected: it should show diff, then apply and it should update and reflect in UI --- Passed
4) Create min=1 , max=2 then check plan , Expected: it should show diff, then apply and it should update and reflect in UI ---Passed
5) Dont change anything and execute "terraform plan" , Expected: it should not show any diff ---Passed
6) Create min=1 max=2 , now set min=0 then disable min ---> Passed
7) Create min=1 max=2 , then disable max , Expected: max should get disable---> Passed 
8) Create min=nil, max=nil , make max,min=1, then disable it, Expected: both should get disable ---> Passed
9) Create using different provider and update using local provider ---> Passed
10) Create min=nil, max=nil , then check plan,  Expected: it should not show diff ---> Passed
