### PR TITLE
Added support for "max_scale_down_percentage" in aws ocean vng.

### DIFF
--- a/docs/resources/ocean_aws_launch_spec.md
+++ b/docs/resources/ocean_aws_launch_spec.md
@@ -58,7 +58,11 @@ resource "spotinst_ocean_aws_launch_spec" "example" {
     gpu_per_unit    = 0
     memory_per_unit = 2048
   }
-
+  
+  autoscale_down {
+    max_scale_down_percentage    = 20
+  }
+  
   elastic_ip_pool {
     tag_selector {
       tag_key   = "key"
@@ -180,6 +184,8 @@ The following arguments are supported:
     * `cpu_per_unit` - (Optional) Optionally configure the number of CPUs to allocate for each headroom unit. CPUs are denoted in millicores, where 1000 millicores = 1 vCPU.
     * `gpu_per_unit` - (Optional) Optionally configure the number of GPUS to allocate for each headroom unit.
     * `memory_per_unit` - (Optional) Optionally configure the amount of memory (MiB) to allocate for each headroom unit.
+* `autoscale_down` - (Optional) Auto Scaling scale down operations.
+    * `max_scale_down_percentage` - (Optional) The maximum percentage allowed to scale down in a single scaling action on the nodes running in a specific VNG. Allowed only if maxScaleDownPercentage is set to null at the cluster level. Number between [0.1-100].
 * `resource_limits` - (Optional) 
     * `max_instance_count` - (Optional) Set a maximum number of instances per Virtual Node Group. Can be null. If set, value must be greater than or equal to 0.
     * `min_instance_count` - (Optional) Set a minimum number of instances per Virtual Node Group. Can be null. If set, value must be greater than or equal to 0.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
-	github.com/spotinst/spotinst-sdk-go v1.139.0
+	github.com/spotinst/spotinst-sdk-go v1.140.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 
 )

--- a/go.sum
+++ b/go.sum
@@ -352,8 +352,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.139.0 h1:/kfEMzp42GRyiCJOSMQPLXWmfZLzWUYlb55Zb5TXqCI=
-github.com/spotinst/spotinst-sdk-go v1.139.0/go.mod h1:Ku9c4p+kRWnQqmXkzGcTMHLcQKgLHrQZISxeKY7mPqE=
+github.com/spotinst/spotinst-sdk-go v1.140.0 h1:3wEgfpJpk7oF0YPwt2XWDkjGeBlTH3iP9htYwXo8NRg=
+github.com/spotinst/spotinst-sdk-go v1.140.0/go.mod h1:Ku9c4p+kRWnQqmXkzGcTMHLcQKgLHrQZISxeKY7mPqE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/ocean_aws_launch_spec/consts.go
+++ b/spotinst/ocean_aws_launch_spec/consts.go
@@ -62,6 +62,8 @@ const (
 	RestrictScaleDown        commons.FieldName = "restrict_scale_down"
 	SchedulingTask           commons.FieldName = "scheduling_task"
 	SchedulingShutdownHours  commons.FieldName = "scheduling_shutdown_hours"
+	AutoscaleDown            commons.FieldName = "autoscale_down"
+	MaxScaleDownPercentage   commons.FieldName = "max_scale_down_percentage"
 )
 
 const (


### PR DESCRIPTION
Added support for "max_scale_down_percentage" in aws ocean vng.
Ref: https://spotinst.atlassian.net/browse/SPOTAUT-13167