### PR TITLE
Added support for instanceMetadataOptions in Ocean AWS and ECS VNG.

### DIFF
--- a/docs/resources/ocean_aws_launch_spec.md
+++ b/docs/resources/ocean_aws_launch_spec.md
@@ -109,6 +109,11 @@ resource "spotinst_ocean_aws_launch_spec" "example" {
     delete_nodes = true
   }
   
+  instance_metadata_options {
+    http_tokens = "required"
+    http_put_response_hop_limit = 10
+  }
+  
   scheduling_task {
     is_enabled = true
     cron_expression = "0 1 * * *"
@@ -208,6 +213,9 @@ The following arguments are supported:
 * `scheduling_shutdown_hours` - (Optional) Used to specify times that the nodes in the virtual node group will be taken down.
     * `time_windows` - (Required ) The times that the shutdown hours will apply.
     * `is_enabled` - (Optional) Flag to enable or disable the shutdown hours mechanism. When False, the mechanism is deactivated, and the virtual node group remains in its current state.
+* `instance_metadata_options` - (Optional) Ocean instance metadata options object for IMDSv2.
+    * `http_tokens` - (Required) Determines if a signed token is required or not. Valid values: `optional` or `required`.
+    * `http_put_response_hop_limit` - (Optional) An integer from 1 through 64. The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further the instance metadata requests can travel.
 
 <a id="update-policy"></a>
 ## Update Policy

--- a/docs/resources/ocean_ecs_launch_spec.md
+++ b/docs/resources/ocean_ecs_launch_spec.md
@@ -48,6 +48,11 @@ resource "spotinst_ocean_ecs_launch_spec" "example" {
     value = "fakeValue"
   }
   
+  instance_metadata_options {
+    http_tokens = "required"
+    http_put_response_hop_limit = 10
+  }
+  
   autoscale_headrooms {
     num_of_units = 5
     cpu_per_unit = 1000
@@ -96,6 +101,9 @@ The following arguments are supported:
 * `preferred_spot_types` - (Optional) When Ocean scales up instances, it takes your preferred types into consideration while maintaining a variety of machine types running for optimized distribution.
 * `restrict_scale_down`- (Optional) Boolean. When set to “True”, VNG nodes will be treated as if all pods running have the restrict-scale-down label. Therefore, Ocean will not scale nodes down unless empty.
 * `subnet_ids` - (Optional) Set subnets in launchSpec. Each element in the array should be a subnet ID.
+* `instance_metadata_options` - (Optional) Ocean instance metadata options object for IMDSv2.
+    * `http_tokens` - (Required) Determines if a signed token is required or not. Valid values: `optional` or `required`.
+    * `http_put_response_hop_limit` - (Optional) An integer from 1 through 64. The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further the instance metadata requests can travel.
 
 * `attributes` - (Optional) Optionally adds labels to instances launched in an Ocean cluster.
     * `key` - (Required) The label key.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
-	github.com/spotinst/spotinst-sdk-go v1.142.0
+	github.com/spotinst/spotinst-sdk-go v1.143.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 
 )

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
-	github.com/spotinst/spotinst-sdk-go v1.141.0
+	github.com/spotinst/spotinst-sdk-go v1.142.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 
 )

--- a/go.sum
+++ b/go.sum
@@ -352,8 +352,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.141.0 h1:33N/0PXip94ldqNr5VVqH0jHTcvJG7qcsL/7AF0WmyE=
-github.com/spotinst/spotinst-sdk-go v1.141.0/go.mod h1:Ku9c4p+kRWnQqmXkzGcTMHLcQKgLHrQZISxeKY7mPqE=
+github.com/spotinst/spotinst-sdk-go v1.142.0 h1:6igDDu3x4kPNyLFBv/ezH6PP6D32054xtgr+6qrF3pY=
+github.com/spotinst/spotinst-sdk-go v1.142.0/go.mod h1:Ku9c4p+kRWnQqmXkzGcTMHLcQKgLHrQZISxeKY7mPqE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/go.sum
+++ b/go.sum
@@ -352,8 +352,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.142.0 h1:6igDDu3x4kPNyLFBv/ezH6PP6D32054xtgr+6qrF3pY=
-github.com/spotinst/spotinst-sdk-go v1.142.0/go.mod h1:Ku9c4p+kRWnQqmXkzGcTMHLcQKgLHrQZISxeKY7mPqE=
+github.com/spotinst/spotinst-sdk-go v1.143.0 h1:+MJ5236eOJYWfnO9gl28+6ycnBA7Clo6V0REtTka154=
+github.com/spotinst/spotinst-sdk-go v1.143.0/go.mod h1:Ku9c4p+kRWnQqmXkzGcTMHLcQKgLHrQZISxeKY7mPqE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/ocean_aws_launch_configuration/fields_spotinst_ocean_aws_launch_configuration.go
+++ b/spotinst/ocean_aws_launch_configuration/fields_spotinst_ocean_aws_launch_configuration.go
@@ -575,7 +575,8 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 					string(HTTPPutResponseHopLimit): {
 						Type:     schema.TypeInt,
 						Optional: true,
-						Default:  1357997531,
+						// Value mentioned below is used to set HTTPPutResponseHopLimit field to null when the customer doesn't want to set this param, as terraform set it 0 for integer type param by default
+						Default: 1357997531,
 					},
 				},
 			},
@@ -703,6 +704,7 @@ func expandInstanceMetadataOptions(data interface{}) (*aws.InstanceMetadataOptio
 		instanceMetadataOptions.SetHTTPTokens(spotinst.String(v))
 	}
 	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok {
+		// Value(1357997531) mentioned below is used to set HTTPPutResponseHopLimit field to null when the customer doesn't want to set this param, as terraform set it 0 for integer type param by default.
 		if v == 1357997531 {
 			instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
 		} else {

--- a/spotinst/ocean_aws_launch_configuration/fields_spotinst_ocean_aws_launch_configuration.go
+++ b/spotinst/ocean_aws_launch_configuration/fields_spotinst_ocean_aws_launch_configuration.go
@@ -575,6 +575,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 					string(HTTPPutResponseHopLimit): {
 						Type:     schema.TypeInt,
 						Optional: true,
+						Default:  1357997531,
 					},
 				},
 			},
@@ -701,10 +702,12 @@ func expandInstanceMetadataOptions(data interface{}) (*aws.InstanceMetadataOptio
 	if v, ok := m[string(HTTPTokens)].(string); ok && v != "" {
 		instanceMetadataOptions.SetHTTPTokens(spotinst.String(v))
 	}
-	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok && v >= 0 {
-		instanceMetadataOptions.SetHTTPPutResponseHopLimit(spotinst.Int(v))
-	} else {
-		instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
+	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok {
+		if v == 1357997531 {
+			instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
+		} else {
+			instanceMetadataOptions.SetHTTPPutResponseHopLimit(spotinst.Int(v))
+		}
 	}
 
 	return instanceMetadataOptions, nil

--- a/spotinst/ocean_aws_launch_spec/consts.go
+++ b/spotinst/ocean_aws_launch_spec/consts.go
@@ -119,3 +119,9 @@ const (
 const (
 	TimeWindows commons.FieldName = "time_windows"
 )
+
+const (
+	InstanceMetadataOptions commons.FieldName = "instance_metadata_options"
+	HTTPTokens              commons.FieldName = "http_tokens"
+	HTTPPutResponseHopLimit commons.FieldName = "http_put_response_hop_limit"
+)

--- a/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
+++ b/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
@@ -1577,7 +1577,8 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 					string(HTTPPutResponseHopLimit): {
 						Type:     schema.TypeInt,
 						Optional: true,
-						Default:  1357997531,
+						// Value mentioned below is used to set HTTPPutResponseHopLimit field to null when the customer doesn't want to set this param, as terraform set it 0 for integer type param by default
+						Default: 1357997531,
 					},
 				},
 			},
@@ -2405,6 +2406,7 @@ func expandInstanceMetadataOptions(data interface{}) (*aws.LaunchspecInstanceMet
 		instanceMetadataOptions.SetHTTPTokens(spotinst.String(v))
 	}
 	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok {
+		// Value(1357997531) mentioned below is used to set HTTPPutResponseHopLimit field to null when the customer doesn't want to set this param, as terraform set it 0 for integer type param by default.
 		if v == 1357997531 {
 			instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
 		} else {

--- a/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
+++ b/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
@@ -1577,6 +1577,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 					string(HTTPPutResponseHopLimit): {
 						Type:     schema.TypeInt,
 						Optional: true,
+						Default:  1357997531,
 					},
 				},
 			},
@@ -2403,10 +2404,12 @@ func expandInstanceMetadataOptions(data interface{}) (*aws.LaunchspecInstanceMet
 	if v, ok := m[string(HTTPTokens)].(string); ok && v != "" {
 		instanceMetadataOptions.SetHTTPTokens(spotinst.String(v))
 	}
-	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok && v >= 0 {
-		instanceMetadataOptions.SetHTTPPutResponseHopLimit(spotinst.Int(v))
-	} else {
-		instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
+	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok {
+		if v == 1357997531 {
+			instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
+		} else {
+			instanceMetadataOptions.SetHTTPPutResponseHopLimit(spotinst.Int(v))
+		}
 	}
 
 	return instanceMetadataOptions, nil

--- a/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
+++ b/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
@@ -1559,6 +1559,71 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		},
 		nil,
 	)
+
+	fieldsMap[InstanceMetadataOptions] = commons.NewGenericField(
+		commons.OceanAWSLaunchSpec,
+		InstanceMetadataOptions,
+		&schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					string(HTTPTokens): {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					string(HTTPPutResponseHopLimit): {
+						Type:     schema.TypeInt,
+						Optional: true,
+					},
+				},
+			},
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			launchSpecWrapper := resourceObject.(*commons.LaunchSpecWrapper)
+			launchSpec := launchSpecWrapper.GetLaunchSpec()
+			var result []interface{} = nil
+			if launchSpec != nil && launchSpec.InstanceMetadataOptions != nil {
+				result = flattenInstanceMetadataOptions(launchSpec.InstanceMetadataOptions)
+			}
+
+			if result != nil {
+				if err := resourceData.Set(string(InstanceMetadataOptions), result); err != nil {
+					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(InstanceMetadataOptions), err)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			launchSpecWrapper := resourceObject.(*commons.LaunchSpecWrapper)
+			launchSpec := launchSpecWrapper.GetLaunchSpec()
+			if v, ok := resourceData.GetOk(string(InstanceMetadataOptions)); ok {
+				if metaDataOptions, err := expandInstanceMetadataOptions(v); err != nil {
+					return err
+				} else {
+					launchSpec.SetLaunchspecInstanceMetadataOptions(metaDataOptions)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			launchSpecWrapper := resourceObject.(*commons.LaunchSpecWrapper)
+			launchSpec := launchSpecWrapper.GetLaunchSpec()
+			var value *aws.LaunchspecInstanceMetadataOptions = nil
+			if v, ok := resourceData.GetOk(string(InstanceMetadataOptions)); ok {
+				if metaDataOptions, err := expandInstanceMetadataOptions(v); err != nil {
+					return err
+				} else {
+					value = metaDataOptions
+				}
+			}
+			launchSpec.SetLaunchspecInstanceMetadataOptions(value)
+			return nil
+		},
+		nil,
+	)
 }
 
 var InstanceProfileArnRegex = regexp.MustCompile(`arn:aws:iam::\d{12}:instance-profile/?[a-zA-Z_0-9+=,.@\-_/]+`)
@@ -2318,4 +2383,31 @@ func expandAutoscaleDown(down interface{}) (*aws.AutoScalerDownVNG, error) {
 		return autoscaleDown, nil
 	}
 	return nil, nil
+}
+
+func flattenInstanceMetadataOptions(instanceMetadataOptions *aws.LaunchspecInstanceMetadataOptions) []interface{} {
+	result := make(map[string]interface{})
+	result[string(HTTPTokens)] = spotinst.StringValue(instanceMetadataOptions.HTTPTokens)
+	result[string(HTTPPutResponseHopLimit)] = spotinst.IntValue(instanceMetadataOptions.HTTPPutResponseHopLimit)
+
+	return []interface{}{result}
+}
+func expandInstanceMetadataOptions(data interface{}) (*aws.LaunchspecInstanceMetadataOptions, error) {
+	instanceMetadataOptions := &aws.LaunchspecInstanceMetadataOptions{}
+	list := data.([]interface{})
+	if list == nil || list[0] == nil {
+		return instanceMetadataOptions, nil
+	}
+	m := list[0].(map[string]interface{})
+
+	if v, ok := m[string(HTTPTokens)].(string); ok && v != "" {
+		instanceMetadataOptions.SetHTTPTokens(spotinst.String(v))
+	}
+	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok && v >= 0 {
+		instanceMetadataOptions.SetHTTPPutResponseHopLimit(spotinst.Int(v))
+	} else {
+		instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
+	}
+
+	return instanceMetadataOptions, nil
 }

--- a/spotinst/ocean_ecs_launch_spec/consts.go
+++ b/spotinst/ocean_ecs_launch_spec/consts.go
@@ -72,3 +72,9 @@ const (
 	TaskType       commons.FieldName = "task_type"
 	TaskHeadroom   commons.FieldName = "task_headroom"
 )
+
+const (
+	InstanceMetadataOptions commons.FieldName = "instance_metadata_options"
+	HTTPTokens              commons.FieldName = "http_tokens"
+	HTTPPutResponseHopLimit commons.FieldName = "http_put_response_hop_limit"
+)

--- a/spotinst/ocean_ecs_launch_spec/fields_spotinst_ocean_ecs_launch_spec.go
+++ b/spotinst/ocean_ecs_launch_spec/fields_spotinst_ocean_ecs_launch_spec.go
@@ -985,6 +985,71 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		nil,
 	)
 
+	fieldsMap[InstanceMetadataOptions] = commons.NewGenericField(
+		commons.OceanECSLaunchSpec,
+		InstanceMetadataOptions,
+		&schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					string(HTTPTokens): {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					string(HTTPPutResponseHopLimit): {
+						Type:     schema.TypeInt,
+						Optional: true,
+					},
+				},
+			},
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			LaunchSpecWrapper := resourceObject.(*commons.ECSLaunchSpecWrapper)
+			launchSpec := LaunchSpecWrapper.GetLaunchSpec()
+			var result []interface{} = nil
+			if launchSpec != nil && launchSpec.InstanceMetadataOptions != nil {
+				result = flattenInstanceMetadataOptions(launchSpec.InstanceMetadataOptions)
+			}
+
+			if result != nil {
+				if err := resourceData.Set(string(InstanceMetadataOptions), result); err != nil {
+					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(InstanceMetadataOptions), err)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			LaunchSpecWrapper := resourceObject.(*commons.ECSLaunchSpecWrapper)
+			launchSpec := LaunchSpecWrapper.GetLaunchSpec()
+			if v, ok := resourceData.GetOk(string(InstanceMetadataOptions)); ok {
+				if metaDataOptions, err := expandInstanceMetadataOptions(v); err != nil {
+					return err
+				} else {
+					launchSpec.SetECSLaunchspecInstanceMetadataOptions(metaDataOptions)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			LaunchSpecWrapper := resourceObject.(*commons.ECSLaunchSpecWrapper)
+			launchSpec := LaunchSpecWrapper.GetLaunchSpec()
+			var value *aws.ECSLaunchspecInstanceMetadataOptions = nil
+			if v, ok := resourceData.GetOk(string(InstanceMetadataOptions)); ok {
+				if metaDataOptions, err := expandInstanceMetadataOptions(v); err != nil {
+					return err
+				} else {
+					value = metaDataOptions
+				}
+			}
+			launchSpec.SetECSLaunchspecInstanceMetadataOptions(value)
+			return nil
+		},
+		nil,
+	)
+
 }
 
 func expandStrategy(data interface{}) (*aws.ECSLaunchSpecStrategy, error) {
@@ -1454,4 +1519,30 @@ func expandTaskHeadroom(data interface{}) (*aws.ECSTaskConfig, error) {
 	}
 
 	return taskConfig, nil
+}
+func flattenInstanceMetadataOptions(instanceMetadataOptions *aws.ECSLaunchspecInstanceMetadataOptions) []interface{} {
+	result := make(map[string]interface{})
+	result[string(HTTPTokens)] = spotinst.StringValue(instanceMetadataOptions.HTTPTokens)
+	result[string(HTTPPutResponseHopLimit)] = spotinst.IntValue(instanceMetadataOptions.HTTPPutResponseHopLimit)
+
+	return []interface{}{result}
+}
+func expandInstanceMetadataOptions(data interface{}) (*aws.ECSLaunchspecInstanceMetadataOptions, error) {
+	instanceMetadataOptions := &aws.ECSLaunchspecInstanceMetadataOptions{}
+	list := data.([]interface{})
+	if list == nil || list[0] == nil {
+		return instanceMetadataOptions, nil
+	}
+	m := list[0].(map[string]interface{})
+
+	if v, ok := m[string(HTTPTokens)].(string); ok && v != "" {
+		instanceMetadataOptions.SetHTTPTokens(spotinst.String(v))
+	}
+	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok && v >= 0 {
+		instanceMetadataOptions.SetHTTPPutResponseHopLimit(spotinst.Int(v))
+	} else {
+		instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
+	}
+
+	return instanceMetadataOptions, nil
 }

--- a/spotinst/ocean_ecs_launch_spec/fields_spotinst_ocean_ecs_launch_spec.go
+++ b/spotinst/ocean_ecs_launch_spec/fields_spotinst_ocean_ecs_launch_spec.go
@@ -1002,7 +1002,8 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 					string(HTTPPutResponseHopLimit): {
 						Type:     schema.TypeInt,
 						Optional: true,
-						Default:  1357997531,
+						// Value mentioned below is used to set HTTPPutResponseHopLimit field to null when the customer doesn't want to set this param, as terraform set it 0 for integer type param by default
+						Default: 1357997531,
 					},
 				},
 			},
@@ -1540,6 +1541,7 @@ func expandInstanceMetadataOptions(data interface{}) (*aws.ECSLaunchspecInstance
 		instanceMetadataOptions.SetHTTPTokens(spotinst.String(v))
 	}
 	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok {
+		// Value(1357997531) mentioned below is used to set HTTPPutResponseHopLimit field to null when the customer doesn't want to set this param, as terraform set it 0 for integer type param by default.
 		if v == 1357997531 {
 			instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
 		} else {

--- a/spotinst/ocean_ecs_launch_spec/fields_spotinst_ocean_ecs_launch_spec.go
+++ b/spotinst/ocean_ecs_launch_spec/fields_spotinst_ocean_ecs_launch_spec.go
@@ -1002,6 +1002,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 					string(HTTPPutResponseHopLimit): {
 						Type:     schema.TypeInt,
 						Optional: true,
+						Default:  1357997531,
 					},
 				},
 			},
@@ -1538,10 +1539,12 @@ func expandInstanceMetadataOptions(data interface{}) (*aws.ECSLaunchspecInstance
 	if v, ok := m[string(HTTPTokens)].(string); ok && v != "" {
 		instanceMetadataOptions.SetHTTPTokens(spotinst.String(v))
 	}
-	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok && v >= 0 {
-		instanceMetadataOptions.SetHTTPPutResponseHopLimit(spotinst.Int(v))
-	} else {
-		instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
+	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok {
+		if v == 1357997531 {
+			instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
+		} else {
+			instanceMetadataOptions.SetHTTPPutResponseHopLimit(spotinst.Int(v))
+		}
 	}
 
 	return instanceMetadataOptions, nil

--- a/spotinst/ocean_ecs_launch_specification/fields_spotinst_ocean_ecs_launch_specification.go
+++ b/spotinst/ocean_ecs_launch_specification/fields_spotinst_ocean_ecs_launch_specification.go
@@ -611,7 +611,8 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 					string(HTTPPutResponseHopLimit): {
 						Type:     schema.TypeInt,
 						Optional: true,
-						Default:  1357997531,
+						// Value mentioned below is used to set HTTPPutResponseHopLimit field to null when the customer doesn't want to set this param, as terraform set it 0 for integer type param by default
+						Default: 1357997531,
 					},
 				},
 			},
@@ -862,6 +863,7 @@ func expandInstanceMetadataOptions(data interface{}) (*aws.ECSInstanceMetadataOp
 		instanceMetadataOptions.SetHTTPTokens(spotinst.String(v))
 	}
 	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok {
+		// Value(1357997531) mentioned below is used to set HTTPPutResponseHopLimit field to null when the customer doesn't want to set this param, as terraform set it 0 for integer type param by default.
 		if v == 1357997531 {
 			instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
 		} else {

--- a/spotinst/ocean_ecs_launch_specification/fields_spotinst_ocean_ecs_launch_specification.go
+++ b/spotinst/ocean_ecs_launch_specification/fields_spotinst_ocean_ecs_launch_specification.go
@@ -611,6 +611,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 					string(HTTPPutResponseHopLimit): {
 						Type:     schema.TypeInt,
 						Optional: true,
+						Default:  1357997531,
 					},
 				},
 			},
@@ -860,10 +861,12 @@ func expandInstanceMetadataOptions(data interface{}) (*aws.ECSInstanceMetadataOp
 	if v, ok := m[string(HTTPTokens)].(string); ok && v != "" {
 		instanceMetadataOptions.SetHTTPTokens(spotinst.String(v))
 	}
-	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok && v >= 0 {
-		instanceMetadataOptions.SetHTTPPutResponseHopLimit(spotinst.Int(v))
-	} else {
-		instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
+	if v, ok := m[string(HTTPPutResponseHopLimit)].(int); ok {
+		if v == 1357997531 {
+			instanceMetadataOptions.SetHTTPPutResponseHopLimit(nil)
+		} else {
+			instanceMetadataOptions.SetHTTPPutResponseHopLimit(spotinst.Int(v))
+		}
 	}
 
 	return instanceMetadataOptions, nil


### PR DESCRIPTION
Added support for instanceMetadataOptions in Ocean AWS and ECS VNG.

# Jira Ticket
Ref: https://spotinst.atlassian.net/browse/SPOTAUT-13265
Ref: https://spotinst.atlassian.net/browse/SPOTAUT-13358
Ref: https://spotinst.atlassian.net/browse/SPOTAUT-13317