### PR TITLE
fix(elastigroup/aws): fixed `autoscale_attributes` field in `integration_ecs` to read as an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.112.0 (Apr 13, 2023)
+BUG FIXES:
+* resource/spotinst_elastigroup_aws: fixed `autoscale_attributes` field in `integration_ecs` to read as an array
+
 ## 1.111.0 (Apr 13, 2023)
 ENHANCEMENTS:
 * resource/spotinst_ocean_ecs: added `enable_automatic_and_manual_headroom` field in `autoscaler`

--- a/spotinst/elastigroup_aws_integrations/fields_spotinst_elastigroup_aws_integrations_ecs.go
+++ b/spotinst/elastigroup_aws_integrations/fields_spotinst_elastigroup_aws_integrations_ecs.go
@@ -310,14 +310,17 @@ func flattenAutoScale(autoScale *aws.AutoScale) []interface{} {
 }
 
 func flattenECSIntegrationAutoScaleAttributes(attrs []*aws.AutoScaleAttributes) []interface{} {
-	result := make(map[string]interface{})
+	result := make([]interface{}, 0, len(attrs))
 
 	for _, attr := range attrs {
-		result[string(Key)] = spotinst.StringValue(attr.Key)
-		result[string(Value)] = spotinst.StringValue(attr.Value)
+		m := make(map[string]interface{})
+		m[string(Key)] = spotinst.StringValue(attr.Key)
+		m[string(Value)] = spotinst.StringValue(attr.Value)
+
+		result = append(result, m)
 	}
 
-	return []interface{}{result}
+	return result
 }
 
 func flattenECSIntegration(ecs *aws.EC2ContainerServiceIntegration) []interface{} {


### PR DESCRIPTION


# Jira Ticket
https://spotinst.atlassian.net/browse/SPOTAUT-14219
