### PR TITLE
fix(ocean/aws): updated example usage for `images`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+
+## 1.114.0 (Apr 27, 2023)
+NOTES:
+* documentation: resource/spotinst_ocean_aws_launch_spec: updated example usage for `images`
+
 ## 1.113.0 (Apr 20, 2023)
 ENHANCEMENTS:
 * resource/spotinst_ocean_gke_launch_spec: added `network_interfaces` object 

--- a/docs/resources/ocean_aws_launch_spec.md
+++ b/docs/resources/ocean_aws_launch_spec.md
@@ -25,8 +25,11 @@ resource "spotinst_ocean_aws_launch_spec" "example" {
   root_volume_size            = 30
   associate_public_ip_address = true
   
-  images  {
-    image_id = "ami-id"
+  images {
+    image_id = "ami-id1"
+    }
+  images {
+    image_id = "ami-id2"
     }
 
   instance_types = [


### PR DESCRIPTION
fix(ocean/aws): updated example usage for `images`