### PR TITLE
Moving Stateful_node_azure document under StatefulNode structure

### DIFF
--- a/docs/resources/ocean_aws.md
+++ b/docs/resources/ocean_aws.md
@@ -44,13 +44,12 @@ resource "spotinst_ocean_aws" "example" {
   desired_capacity = 2
 
   subnet_ids = ["subnet-123456789"]
+
+  // region INSTANCE-TYPES
   
-  instanceTypes {
-    //whitelist  = ["t1.micro", "m1.small"]
-    
-    //blacklist = ["t1.micro", "m1.small"]
-    
-    filters {
+  //whitelist  = ["t1.micro", "m1.small"]
+  //blacklist = ["t1.micro", "m1.small"]
+  filters {
       architectures             =   ["x86_64", "i386"]
       categories                =   ["Accelerated_computing", "Compute_optimized"]
       disk_types                =   ["EBS", "SSD"]

--- a/docs/resources/stateful_node_azure.md
+++ b/docs/resources/stateful_node_azure.md
@@ -3,7 +3,7 @@ layout: "spotinst"
 page_title: "Spotinst: stateful_node_azure"
 subcategory: "Stateful Node"
 description: |-
-Provides a Spotinst Stateful Node resource using Azure.
+  Provides a Spotinst Stateful Node resource using Azure.
 ---
 
 # spotinst\_stateful\_node\_azure
@@ -220,6 +220,7 @@ resource "spotinst_stateful_node_azure" "test_stateful_node_azure" {
     type    = "vmReady"
     timeout = 40
   }
+}
   // -------------------------------------------------------------------
 
 ```


### PR DESCRIPTION
Moving Stateful_node_azure document under StatefulNode structure and removing instance type from ocean_aws document

# Jira Ticket
Ref: https://spotinst.atlassian.net/browse/SPOTAUT-13728