### PR TITLE
BGD-3394 - remove deprecated `collect_driver_log` property

### DIFF
--- a/docs/resources/ocean_spark.md
+++ b/docs/resources/ocean_spark.md
@@ -58,7 +58,7 @@ resource "spotinst_ocean_spark" "example" {
   }
 
   log_collection {
-    collect_driver_logs = true
+    collect_app_logs = true
   }
 
   webhook {
@@ -155,7 +155,7 @@ Optional:
 
 Optional:
 
-- **collect_driver_logs** (Boolean, default: `true`) - Enable/disable the collection of driver logs. When enabled, driver logs are stored by NetApp and can be downloaded from the Spot console web interface. The driver logs are deleted after 30 days.
+- **collect_app_logs** (Boolean, default: `true`) - Enable/Disable collecting driver and executor logs. When enabled, logs are stored by NetApp and can be downloaded from the Spot console web interface. The logs are deleted after 30 days.
 
 
 <a id="nestedblock--webhook"></a>

--- a/spotinst/ocean_spark_log_collection/consts.go
+++ b/spotinst/ocean_spark_log_collection/consts.go
@@ -3,9 +3,6 @@ package ocean_spark_log_collection
 import "github.com/spotinst/terraform-provider-spotinst/spotinst/commons"
 
 const (
-	LogCollection commons.FieldName = "log_collection"
-	// Deprecated: CollectDriverLogs is obsolete, exists for backward compatibility only,
-	// and should not be used. Please use CollectAppLogs instead.
-	CollectDriverLogs commons.FieldName = "collect_driver_logs"
-	CollectAppLogs    commons.FieldName = "collect_app_logs"
+	LogCollection  commons.FieldName = "log_collection"
+	CollectAppLogs commons.FieldName = "collect_app_logs"
 )

--- a/spotinst/ocean_spark_log_collection/fields_spotinst_ocean_spark_log_collection.go
+++ b/spotinst/ocean_spark_log_collection/fields_spotinst_ocean_spark_log_collection.go
@@ -21,12 +21,6 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 			MaxItems: 1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-
-					string(CollectDriverLogs): {
-						Type:     schema.TypeBool,
-						Optional: true,
-						Computed: true,
-					},
 					string(CollectAppLogs): {
 						Type:     schema.TypeBool,
 						Optional: true,
@@ -90,7 +84,6 @@ func flattenLogCollection(logCollection *spark.LogCollectionConfig) []interface{
 		return nil
 	}
 	result := make(map[string]interface{})
-	result[string(CollectDriverLogs)] = spotinst.BoolValue(logCollection.CollectDriverLogs)
 	result[string(CollectAppLogs)] = spotinst.BoolValue(logCollection.CollectAppLogs)
 	return []interface{}{result}
 }
@@ -103,9 +96,6 @@ func expandLogCollection(data interface{}) (*spark.LogCollectionConfig, error) {
 	}
 	m := list[0].(map[string]interface{})
 
-	if v, ok := m[string(CollectDriverLogs)].(bool); ok {
-		logCollection.SetCollectDriverLogs(spotinst.Bool(v))
-	}
 	if v, ok := m[string(CollectAppLogs)].(bool); ok {
 		logCollection.SetCollectAppLogs(spotinst.Bool(v))
 	}

--- a/spotinst/resource_spotinst_ocean_spark_test.go
+++ b/spotinst/resource_spotinst_ocean_spark_test.go
@@ -428,7 +428,7 @@ func TestAccSpotinstOceanSpark_withLogCollectionConfig(t *testing.T) {
 					testCheckOceanSparkExists(&cluster, resourceName),
 					testCheckOceanSparkAttributes(&cluster, oceanClusterID),
 					resource.TestCheckResourceAttr(resourceName, "log_collection.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "log_collection.0.collect_driver_logs", "true"),
+					resource.TestCheckResourceAttr(resourceName, "log_collection.0.collect_app_logs", "true"),
 				),
 			},
 			{
@@ -440,7 +440,7 @@ func TestAccSpotinstOceanSpark_withLogCollectionConfig(t *testing.T) {
 					testCheckOceanSparkExists(&cluster, resourceName),
 					testCheckOceanSparkAttributes(&cluster, oceanClusterID),
 					resource.TestCheckResourceAttr(resourceName, "log_collection.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "log_collection.0.collect_driver_logs", "false"),
+					resource.TestCheckResourceAttr(resourceName, "log_collection.0.collect_app_logs", "false"),
 				),
 			},
 		},
@@ -855,7 +855,7 @@ const testConfigWithComputeUpdate = `
 const testConfigWithLogCollectionCreate = `
  log_collection {
 
-    collect_driver_logs = true
+    collect_app_logs = true
 
  }
 `
@@ -863,7 +863,7 @@ const testConfigWithLogCollectionCreate = `
 const testConfigWithLogCollectionUpdate = `
  log_collection {
 
-    collect_driver_logs = false
+    collect_app_logs = false
 
  }
 `


### PR DESCRIPTION
Alternative fix for the following issue https://github.com/spotinst/terraform-provider-spotinst/pull/439

Removing the deprecated  `collect_driver_log` property will avoid the situation when both parameters  `collect_driver_log` and  `collect_app_log` are set. 

This is a breaking change that requires updating the TF version and update our TF module