### PR TITLE
Fix typo on minimum_instnace_lifetime

### DIFF
--- a/docs/resources/stateful_node_aws.md
+++ b/docs/resources/stateful_node_aws.md
@@ -112,7 +112,7 @@ The following arguments are supported:
 * `utilize_reserved_instances` - (Optional) In case of any available Reserved Instances, Managed Instance will utilize them before purchasing Spot instances. Default: `"false"`. 
 * `optimization_windows` - (Optional) When `performAt` is `"timeWindow"`: must specify a list of `"timeWindows"` with at least one time window. Each string should be formatted as `ddd:hh:mm-ddd:hh:mm` (ddd = day of week = Sun | Mon | Tue | Wed | Thu | Fri | Sat hh = hour 24 = 0 -23 mm = minute = 0 - 59).
 * `perform_at` - (Optional) Valid values: `"always"`, `"never"`, `"timeWindow"`. Default `"never"`.
-* `minimum_instnace_lifetime` - (Optional) Defines the preferred minimum instance lifetime. Markets which comply with this preference will be prioritized. Optional values: `1`, `3`, `6`, `12`, `24`.
+* `minimum_instance_lifetime` - (Optional) Defines the preferred minimum instance lifetime. Markets which comply with this preference will be prioritized. Optional values: `1`, `3`, `6`, `12`, `24`.
 * `persist_private_ip` - (Optional) Should the instance maintain its private IP.
 * `persist_block_devices` - (Optional) Should the instance maintain its Data volumes. 
 * `persist_root_device` - (Optional) Should the instance maintain its root device volumes.


### PR DESCRIPTION
This is a simple PR to fix a typo for minimum_instance_lifetime.