### PR TITLE
fix: should check if Parameter is set

### DIFF
--- a/spotinst/ocean_aws_scheduling/fields_spotinst_ocean_aws_scheduling.go
+++ b/spotinst/ocean_aws_scheduling/fields_spotinst_ocean_aws_scheduling.go
@@ -233,7 +233,9 @@ func flattenTasks(tasks []*aws.Task) []interface{} {
 		m[string(TasksIsEnabled)] = spotinst.BoolValue(task.IsEnabled)
 		m[string(TaskType)] = spotinst.StringValue(task.Type)
 		m[string(CronExpression)] = spotinst.StringValue(task.CronExpression)
-		m[string(Parameters)] = flattenParameters(task.Parameter)
+		if task.Parameter != nil {
+			m[string(Parameters)] = flattenParameters(task.Parameter)
+		}
 		result = append(result, m)
 	}
 


### PR DESCRIPTION
Otherwise the plugin will crash if the newly added `Parameters` is not set:

```
Stack trace from the terraform-provider-spotinst_v1.160.0 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1036db4]

goroutine 41 [running]:
github.com/spotinst/terraform-provider-spotinst/spotinst/ocean_aws_scheduling.flattenParameters(0x0,
0xc000486cc0, 0x140e34b, 0xf)
    github.com/spotinst/terraform-provider-spotinst/spotinst/ocean_aws_scheduling/fields_spotinst_ocean_aws_scheduling.go:246
    +0x34
```

_This is the default pull request template. You can customize it by adding a `pull_request_template.md` at the root of your repo or inside the `.github` folder._

# Jira Ticket

_Include a link to your Jira Ticket_
_Example: [JIRAISS-1234](https://spotinst.atlassian.net/browse/JIRAISS-1234)_

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_

# Checklist:
- [ ] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [ ] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have validated all the requirements in the Jira task were answered
- [ ] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 
