### PR TITLE
docs: spotinst_credentials_aws takes account_id not accountid

### DIFF
--- a/docs/resources/credentials_aws.md
+++ b/docs/resources/credentials_aws.md
@@ -15,8 +15,8 @@ Provides a Spotinst credential AWS resource.
 ```hcl
 # set credential AWS
 resource "spotinst_credentials_aws" "credential" {
-  iamrole = "arn:aws:iam::1234567890:role/Spot_Iam_Role"
-  accountid = "act-123456"
+  iamrole    = "arn:aws:iam::1234567890:role/Spot_Iam_Role"
+  account_id = "act-123456"
 }
 ```
 
@@ -25,4 +25,4 @@ resource "spotinst_credentials_aws" "credential" {
 The following arguments are supported:
 
 * `iamrole` - (Required) Provide the IAM Role ARN connected to another AWS account 922761411349 and with the latest Spot Policy - https://docs.spot.io/administration/api/spot-policy-in-aws
-* `accountid` - (Required) The ID of the account associated with your token.
+* `account_id` - (Required) The ID of the account associated with your token.


### PR DESCRIPTION
I'm not sure any of the PR template applies, sorry!