### PR TITLE
fix: typo `instance_types_filters` in `spotinst_ocean_aws_launch_spec` terraform example

### DIFF
--- a/docs/resources/ocean_aws_launch_spec.md
+++ b/docs/resources/ocean_aws_launch_spec.md
@@ -139,7 +139,7 @@ resource "spotinst_ocean_aws_launch_spec" "example" {
   }
 }
 
-  instancetypes_filters {
+  instance_types_filters {
     categories                =   ["Accelerated_computing", "Compute_optimized"]
     disk_types                =   ["NVMe", "EBS"]
     exclude_families          =   ["t2","R4*"]


### PR DESCRIPTION
fix: typo `instance_types_filters` in `spotinst_ocean_aws_launch_spec` terraform example