### PR TITLE
Fixed `labels` updation in `spotinst_ocean_aks_np_virtual_node_group` and added default value for `health_check_unhealthy_duration_before_replacement` in `spotinst_ocean_aws`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## 1.169.1 (April, 10 2024)
+BUG FIXES:
+* resource/spotinst_ocean_aks_np_virtual_node_group: Fixed `labels` failing to update.
+* resource/spotinst_ocean_aws: Fixed drift by adding default value for `health_check_unhealthy_duration_before_replacement`.
+
 ## 1.169.0 (April, 08 2024)
 ENHANCEMENTS:
 * resource/spotinst_ocean_aks_np: Added support for `gpu_types` field in `filters` block.

--- a/spotinst/ocean_aks_np_virtual_node_group/fields_spotinst_ocean_aks_np_virtual_node_group.go
+++ b/spotinst/ocean_aks_np_virtual_node_group/fields_spotinst_ocean_aks_np_virtual_node_group.go
@@ -263,7 +263,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 			virtualNodeGroupWrapper := resourceObject.(*commons.VirtualNodeGroupAKSNPWrapper)
 			virtualNodeGroup := virtualNodeGroupWrapper.GetVirtualNodeGroup()
 			result := make(map[string]string)
-			if virtualNodeGroup.Tags != nil {
+			if virtualNodeGroup.Labels != nil {
 				result = flattenLabels(*virtualNodeGroup.Labels)
 			}
 			if err := resourceData.Set(string(Labels), result); err != nil {

--- a/spotinst/ocean_aws_launch_configuration/fields_spotinst_ocean_aws_launch_configuration.go
+++ b/spotinst/ocean_aws_launch_configuration/fields_spotinst_ocean_aws_launch_configuration.go
@@ -904,6 +904,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		&schema.Schema{
 			Type:     schema.TypeInt,
 			Optional: true,
+			Default:  120,
 		},
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			clusterWrapper := resourceObject.(*commons.AWSClusterWrapper)


### PR DESCRIPTION
Fixed `labels` updation in `spotinst_ocean_aks_np_virtual_node_group` and added default value for `health_check_unhealthy_duration_before_replacement` in `spotinst_ocean_aws`.

# Jira Ticket
Ref: https://spotinst.atlassian.net/browse/SPOTAUT-18407
Ref: https://spotinst.atlassian.net/browse/SPOTAUT-18365