### PR TITLE
added `attach_load_balancer` and `detach_load_balancer` blocks support for attaching and detaching loadBalancers to ocean aws cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.172.0 (May, 08 2024)
+ENHANCEMENTS:
+* resource/spotinst_ocean_aws: added `attach_load_balancer` and `detach_load_balancer` blocks support for attaching and detaching loadBalancers to ocean aws cluster.
+
 ## 1.171.4 (May, 06 2024)
 BUG FIXES:
 * resource/spotinst_ocean_gke_import: Fixed disabling `parameters` under `tasks` in cluster config .

--- a/docs/resources/ocean_aws.md
+++ b/docs/resources/ocean_aws.md
@@ -387,6 +387,47 @@ scheduled_task {
 }
 ```
 
+<a id="attach_load_balancer"></a>
+## Attach LoadBalancer
+
+* `attach_load_balancer` - (Optional) Attach load balancers to the cluster.
+    * `arn`  - (Optional) If type is "TARGET_GROUP" then an ARN is required. Otherwise is not allowed.
+    * `name` - (Optional) If type is "CLASSIC" then a name is required. Otherwise is not allowed.
+    * `type` - (Required, Enum: `"CLASSIC", "TARGET_GROUP"`) Type of load balancer to use.
+
+```hcl
+attach_load_balancer {
+     type = "CLASSIC"
+     name = "LoadBalancerName"
+}
+   
+attach_load_balancer {
+    type = "TARGET_GROUP"
+    arn = "TargetGroupArn"
+}
+```
+    
+
+<a id="detach_load_balancer"></a>
+## Detach LoadBalancer
+
+* `detach_load_balancer` - (Optional) Detach load balancers from the cluster.
+    * `arn`  - (Optional) If type is "TARGET_GROUP" then an ARN is required. Otherwise is not allowed.
+    * `name` - (Optional) If type is "CLASSIC" then a name is required. Otherwise is not allowed.
+    * `type` - (Required, Enum: `"CLASSIC", "TARGET_GROUP"`) Type of load balancer to use.
+
+```hcl
+detach_load_balancer {
+     type = "CLASSIC"
+     name = "LoadBalancerName"
+}
+   
+detach_load_balancer {
+    type = "TARGET_GROUP"
+    arn = "TargetGroupArn"
+}
+```
+
 <a id="attributes-reference"></a>
 ## Attributes Reference
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.2.0
-	github.com/spotinst/spotinst-sdk-go v1.342.0
+	github.com/spotinst/spotinst-sdk-go v1.345.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 )
 

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/sethvargo/go-password v0.2.0 h1:BTDl4CC/gjf/axHMaDQtw507ogrXLci6XRiLc
 github.com/sethvargo/go-password v0.2.0/go.mod h1:Ym4Mr9JXLBycr02MFuVQ/0JHidNetSgbzutTr3zsYXE=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.342.0 h1:YzOZVcnLKs18vJLKSKjrOaJDUBHRV+uQD0UW+8cpgGE=
-github.com/spotinst/spotinst-sdk-go v1.342.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.345.0 h1:zXHeXV6vI2avfQheMSXLsIdL7pnffEid/UQ3dlB+K9w=
+github.com/spotinst/spotinst-sdk-go v1.345.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/spotinst/ocean_aws/consts.go
+++ b/spotinst/ocean_aws/consts.go
@@ -34,3 +34,11 @@ const (
 	BatchMinHealthyPercentage commons.FieldName = "batch_min_healthy_percentage"
 	RespectPDB                commons.FieldName = "respect_pdb"
 )
+
+const (
+	AttachLoadBalancer commons.FieldName = "attach_load_balancer"
+	LoadBalancerArn    commons.FieldName = "arn"
+	LoadBalancerName   commons.FieldName = "name"
+	LoadBalancerType   commons.FieldName = "type"
+	DetachLoadBalancer commons.FieldName = "detach_load_balancer"
+)

--- a/spotinst/ocean_aws/fields_spotinst_ocean_aws.go
+++ b/spotinst/ocean_aws/fields_spotinst_ocean_aws.go
@@ -404,6 +404,76 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		},
 		nil, nil, nil, nil,
 	)
+
+	fieldsMap[AttachLoadBalancer] = commons.NewGenericField(
+		commons.OceanAWS,
+		AttachLoadBalancer,
+		&schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					string(LoadBalancerArn): {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					string(LoadBalancerName): {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					string(LoadBalancerType): {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			return nil
+		},
+		nil,
+	)
+
+	fieldsMap[DetachLoadBalancer] = commons.NewGenericField(
+		commons.OceanAWS,
+		DetachLoadBalancer,
+		&schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					string(LoadBalancerArn): {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					string(LoadBalancerName): {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					string(LoadBalancerType): {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			return nil
+		},
+		nil,
+	)
 }
 
 func expandSubnetIDs(data interface{}) ([]string, error) {

--- a/spotinst/resource_spotinst_organization_user_test.go
+++ b/spotinst/resource_spotinst_organization_user_test.go
@@ -58,7 +58,7 @@ func testCheckOrganizationUserExists(user *organization.User, resourceName strin
 }
 
 func generateRandomPassword() string {
-	res, err := password.Generate(32, 10, 0, false, false)
+	res, err := password.Generate(32, 10, 1, false, false)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
added `attach_load_balancer` and `detach_load_balancer` blocks support for attaching and detaching loadBalancers to ocean aws cluster.

https://spotinst.atlassian.net/browse/SPOTAUT-18602