### PR TITLE
Fixed deletion of `autoscale_headroom` objects and attributes from autoScaler config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.172.1 (May, 16 2024)
+BUG FIXES:
+* resource/spotinst_ocean_aws: Fixed disabling of `autoscale_headroom` object and its attributes in cluster config under `autoscaler`.
+
 ## 1.172.0 (May, 08 2024)
 ENHANCEMENTS:
 * resource/spotinst_ocean_aws: added `attach_load_balancer` and `detach_load_balancer` blocks support for attaching and detaching loadBalancers to ocean aws cluster.

--- a/spotinst/ocean_aws_auto_scaling/fields_spotinst_ocean_aws_auto_scaling.go
+++ b/spotinst/ocean_aws_auto_scaling/fields_spotinst_ocean_aws_auto_scaling.go
@@ -68,20 +68,24 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 								string(CPUPerUnit): {
 									Type:     schema.TypeInt,
 									Optional: true,
+									Default:  -1,
 								},
 
 								string(GPUPerUnit): {
 									Type:     schema.TypeInt,
 									Optional: true,
+									Default:  -1,
 								},
 								string(MemoryPerUnit): {
 									Type:     schema.TypeInt,
 									Optional: true,
+									Default:  -1,
 								},
 
 								string(NumOfUnits): {
 									Type:     schema.TypeInt,
 									Optional: true,
+									Default:  -1,
 								},
 							},
 						},
@@ -209,7 +213,7 @@ func expandAutoscaler(data interface{}, nullify bool) (*aws.AutoScaler, error) {
 		if headroom != nil {
 			autoscaler.SetHeadroom(headroom)
 		} else {
-			autoscaler.Headroom = nil
+			autoscaler.SetHeadroom(nil)
 		}
 	}
 
@@ -280,18 +284,26 @@ func expandOceanAWSAutoScalerHeadroom(data interface{}) (*aws.AutoScalerHeadroom
 
 			if v, ok := m[string(CPUPerUnit)].(int); ok && v >= 0 {
 				headroom.SetCPUPerUnit(spotinst.Int(v))
+			} else {
+				headroom.SetCPUPerUnit(nil)
 			}
 
 			if v, ok := m[string(MemoryPerUnit)].(int); ok && v >= 0 {
 				headroom.SetMemoryPerUnit(spotinst.Int(v))
+			} else {
+				headroom.SetMemoryPerUnit(nil)
 			}
 
 			if v, ok := m[string(NumOfUnits)].(int); ok && v >= 0 {
 				headroom.SetNumOfUnits(spotinst.Int(v))
+			} else {
+				headroom.SetNumOfUnits(nil)
 			}
 
 			if v, ok := m[string(GPUPerUnit)].(int); ok && v >= 0 {
 				headroom.SetGPUPerUnit(spotinst.Int(v))
+			} else {
+				headroom.SetGPUPerUnit(nil)
 			}
 		}
 		return headroom, nil


### PR DESCRIPTION
Fixed deletion of `autoscale_headroom` objects and attributes from autoScaler config.

# Jira Ticket
Ref: https://spotinst.atlassian.net/browse/SPOTAUT-18722