### PR TITLE
Fixed removing `autoscale_headroom` when none of its attribute value is passed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.172.3 (May, 17 2024)
 BUG FIXES:
-* resource/spotinst_ocean_aws: Fixed disabling `autoscale_headroom` block none of its attributes are passed in config.
+* resource/spotinst_ocean_aws: Fixed `autoscale_headroom` block to set to null when underlying attributes are not passed in config.
 
 ## 1.172.2 (May, 17 2024)
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.172.3 (May, 17 2024)
+BUG FIXES:
+* resource/spotinst_ocean_aws: Fixed disabling `autoscale_headroom` block none of its attributes are passed in config.
+
 ## 1.172.2 (May, 17 2024)
 BUG FIXES:
 * resource/spotinst_ocean_aws: reverting th fix done for `autoscale_headroom` block.

--- a/spotinst/ocean_aws_auto_scaling/fields_spotinst_ocean_aws_auto_scaling.go
+++ b/spotinst/ocean_aws_auto_scaling/fields_spotinst_ocean_aws_auto_scaling.go
@@ -68,20 +68,24 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 								string(CPUPerUnit): {
 									Type:     schema.TypeInt,
 									Optional: true,
+									Default:  -1,
 								},
 
 								string(GPUPerUnit): {
 									Type:     schema.TypeInt,
 									Optional: true,
+									Default:  -1,
 								},
 								string(MemoryPerUnit): {
 									Type:     schema.TypeInt,
 									Optional: true,
+									Default:  -1,
 								},
 
 								string(NumOfUnits): {
 									Type:     schema.TypeInt,
 									Optional: true,
+									Default:  -1,
 								},
 							},
 						},
@@ -209,7 +213,7 @@ func expandAutoscaler(data interface{}, nullify bool) (*aws.AutoScaler, error) {
 		if headroom != nil {
 			autoscaler.SetHeadroom(headroom)
 		} else {
-			autoscaler.Headroom = nil
+			autoscaler.SetHeadroom(nil)
 		}
 	}
 
@@ -280,18 +284,29 @@ func expandOceanAWSAutoScalerHeadroom(data interface{}) (*aws.AutoScalerHeadroom
 
 			if v, ok := m[string(CPUPerUnit)].(int); ok && v >= 0 {
 				headroom.SetCPUPerUnit(spotinst.Int(v))
+			} else {
+				headroom.SetCPUPerUnit(nil)
 			}
 
 			if v, ok := m[string(MemoryPerUnit)].(int); ok && v >= 0 {
 				headroom.SetMemoryPerUnit(spotinst.Int(v))
+			} else {
+				headroom.SetMemoryPerUnit(nil)
 			}
 
 			if v, ok := m[string(NumOfUnits)].(int); ok && v >= 0 {
 				headroom.SetNumOfUnits(spotinst.Int(v))
+			} else {
+				headroom.SetNumOfUnits(nil)
 			}
 
 			if v, ok := m[string(GPUPerUnit)].(int); ok && v >= 0 {
 				headroom.SetGPUPerUnit(spotinst.Int(v))
+			} else {
+				headroom.SetGPUPerUnit(nil)
+			}
+			if headroom.MemoryPerUnit == nil && headroom.GPUPerUnit == nil && headroom.CPUPerUnit == nil && headroom.NumOfUnits == nil {
+				headroom = nil
 			}
 		}
 		return headroom, nil


### PR DESCRIPTION
Fixed removing `autoscale_headroom` when none of its attribute value is passed.