### PR TITLE
feat(stateful_node/azure): Added support for `encryption_at_host` and `confidential_os_disk_encryption` in `security` block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.184.0 (August, 06 2024)
+ENHANCEMENTS:
+* resource/spotinst_stateful_node_azure: Added `encryption_at_host` and `confidential_os_disk_encryption` in `security` block.
+
 ## 1.183.0 (August, 06 2024)
 ENHANCEMENTS:
 * resource/spotinst_managed_instance_aws: Added support for `metadata_options`.

--- a/docs/resources/stateful_node_azure.md
+++ b/docs/resources/stateful_node_azure.md
@@ -203,9 +203,11 @@ resource "spotinst_stateful_node_azure" "test_stateful_node_azure" {
   // --- Security ------------------------------------------------------
 
   security {
-    security_type = "Standard"
-    secure_boot_enabled = false
-    vtpm_enabled = false
+    security_type = "ConfidentialVM"
+    secure_boot_enabled = true
+    vtpm_enabled = true
+    encryption_at_host = false
+    confidential_os_disk_encryption = true
   }
   // -------------------------------------------------------------------
   
@@ -474,6 +476,8 @@ The following arguments are supported:
     * `secure_boot_enabled` - (Optional) Specifies whether secure boot should be enabled on the virtual machine.
     * `security_type` - (Optional) Enum: `"Standard", "TrustedLaunch"` Security type refers to the different security features of a virtual machine. Security features like Trusted launch virtual machines help to improve the security of Azure generation 2 virtual machines.
     * `vtpm_enabled` - (Optional) Specifies whether vTPM should be enabled on the virtual machine.
+    * `encryption_at_host` - (Optional) Enables the Host Encryption for the virtual machine. The Encryption at host will be disabled unless this property is set to true for the resource.
+    * `confidential_os_disk_encryption` - (Optional) Confidential disk encryption binds the disk encryption keys to the VM's TPM, ensuring VM-only access. The security type must be "ConfidentialVM" to enable defining this preference as “true”.
 
 
 <a id="tag"></a>

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.359.0
+	github.com/spotinst/spotinst-sdk-go v1.361.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,8 @@ github.com/sethvargo/go-password v0.3.1/go.mod h1:rXofC1zT54N7R8K/h1WDUdkf9BOx5O
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.359.0 h1:TG4uJx7X+f+VAFnpMnZWM/85K7S/JdGKAMY2Idznx0k=
-github.com/spotinst/spotinst-sdk-go v1.359.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.361.0 h1:wYIW68kO5fBy/TVeOBFwiyB6JWQLh6bKDutWLgU2rMo=
+github.com/spotinst/spotinst-sdk-go v1.361.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/spotinst/azure_v3/stateful_node_azure_launch_spec/consts.go
+++ b/spotinst/azure_v3/stateful_node_azure_launch_spec/consts.go
@@ -59,8 +59,10 @@ const (
 
 // Security
 const (
-	Security          commons.FieldName = "security"
-	SecureBootEnabled commons.FieldName = "secure_boot_enabled"
-	SecurityType      commons.FieldName = "security_type"
-	VTpmEnabled       commons.FieldName = "vtpm_enabled"
+	Security                     commons.FieldName = "security"
+	SecureBootEnabled            commons.FieldName = "secure_boot_enabled"
+	SecurityType                 commons.FieldName = "security_type"
+	VTpmEnabled                  commons.FieldName = "vtpm_enabled"
+	EncryptionAtHost             commons.FieldName = "encryption_at_host"
+	ConfidentialOsDiskEncryption commons.FieldName = "confidential_os_disk_encryption"
 )

--- a/spotinst/azure_v3/stateful_node_azure_launch_spec/fields_spotinst_stateful_node_azure_launch_spec.go
+++ b/spotinst/azure_v3/stateful_node_azure_launch_spec/fields_spotinst_stateful_node_azure_launch_spec.go
@@ -707,6 +707,14 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 						Type:     schema.TypeBool,
 						Optional: true,
 					},
+					string(EncryptionAtHost): {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					string(ConfidentialOsDiskEncryption): {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
 				},
 			},
 		},
@@ -979,6 +987,8 @@ func flattenSecurity(secure *azure.Security) interface{} {
 	security[string(SecureBootEnabled)] = spotinst.BoolValue(secure.SecureBootEnabled)
 	security[string(SecurityType)] = spotinst.StringValue(secure.SecurityType)
 	security[string(VTpmEnabled)] = spotinst.BoolValue(secure.VTpmEnabled)
+	security[string(EncryptionAtHost)] = spotinst.BoolValue(secure.EncryptionAtHost)
+	security[string(ConfidentialOsDiskEncryption)] = spotinst.BoolValue(secure.ConfidentialOsDiskEncryption)
 
 	return []interface{}{security}
 }
@@ -1000,6 +1010,14 @@ func expandSecurity(data interface{}) (*azure.Security, error) {
 
 			if v, ok := m[string(VTpmEnabled)].(bool); ok {
 				security.SetVTpmEnabled(spotinst.Bool(v))
+			}
+
+			if v, ok := m[string(EncryptionAtHost)].(bool); ok {
+				security.SetEncryptionAtHost(spotinst.Bool(v))
+			}
+
+			if v, ok := m[string(ConfidentialOsDiskEncryption)].(bool); ok {
+				security.SetConfidentialOsDiskEncryption(spotinst.Bool(v))
 			}
 
 		}


### PR DESCRIPTION
Added support for `encryption_at_host` and `confidential_os_disk_encryption` in `security` block.

https://spotinst.atlassian.net/browse/SPOTAUT-19457