### PR TITLE
Added support for `utilize_commitments` and `utilize_reserved_instances` under strategy in spotinst_ocean_aws_launch_spec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.191.0 (September, 12 2024)
+ENHANCEMENTS:
+* resource/spotinst_ocean_aws_launch_spec: Added support for `utilize_commitments` and `utilize_reserved_instances` under strategy.
+
 ## 1.190.0 (August, 30 2024)
 ENHANCEMENTS:
 * resource/spotinst_elastigroup_azure_v3: Added support for `gallery_image` block in `image`.

--- a/docs/resources/ocean_aws_launch_spec.md
+++ b/docs/resources/ocean_aws_launch_spec.md
@@ -115,6 +115,8 @@ resource "spotinst_ocean_aws_launch_spec" "example" {
   strategy {
     spot_percentage = 70
     draining_timeout = 300
+    utilize_commitments= false
+    utilize_reserved_instances= true
   }
   
   create_options {
@@ -239,6 +241,8 @@ The following arguments are supported:
 * `strategy` - (Optional) 
     * `spot_percentage` - (Optional) The desired percentage of the Spot instances out of all running instances for this VNG. Only available when the field is not set in the cluster directly (cluster.strategy.spotPercentage).
     * `draining_timeout` - (Optional, >=300) The configurable amount of time that Ocean will wait for the draining process to complete before terminating an instance. If you have not defined a draining timeout, the default of 300 seconds will be used.
+    * `utilize_commitments` - (Optional, Default: `false`) When set as ‘true’, if savings plans commitments have available capacity, Ocean will utilize them alongside RIs (if exist) to maximize cost efficiency. If the value is set as 'null', it will automatically be inherited from the cluster level.
+    * `utilize_reserved_instances` - (Optional, Default: `true`) When set as ‘true’, if reserved instances exist, Ocean will utilize them before launching spot instances. If the value is set as 'null', it will automatically be inherited from the cluster level.
 * `create_options` - (Optional)
     * `initial_nodes` - (Optional) When set to an integer greater than 0, a corresponding amount of nodes will be launched from the created Virtual Node Group. The parameter is recommended in case the use_as_template_only (in spotinst_ocean_aws resource) is set to true during Ocean resource creation.
 * `delete_options` - (Optional)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.367.0
+	github.com/spotinst/spotinst-sdk-go v1.368.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.367.0 h1:BwkssGZUQXNfefRJvvjDbkYdXCZluYolLct4Jh5qupQ=
-github.com/spotinst/spotinst-sdk-go v1.367.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.368.0 h1:CV0w6C6EKK3s4R5B+OkAwx2abt7Kx+Qcd5EvrBsCBog=
+github.com/spotinst/spotinst-sdk-go v1.368.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/elastigroup_gcp_strategy/fields_spotinst_elastigroup_gcp_strategy.go
+++ b/spotinst/elastigroup_gcp_strategy/fields_spotinst_elastigroup_gcp_strategy.go
@@ -2,6 +2,7 @@ package elastigroup_gcp_strategy
 
 import (
 	"fmt"
+
 	"github.com/spotinst/spotinst-sdk-go/service/elastigroup/providers/gcp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/spotinst/ocean_aws_launch_spec/consts.go
+++ b/spotinst/ocean_aws_launch_spec/consts.go
@@ -89,8 +89,10 @@ const (
 )
 
 const (
-	SpotPercentage  commons.FieldName = "spot_percentage"
-	DrainingTimeout commons.FieldName = "draining_timeout"
+	SpotPercentage           commons.FieldName = "spot_percentage"
+	DrainingTimeout          commons.FieldName = "draining_timeout"
+	UtilizeCommitments       commons.FieldName = "utilize_commitments"
+	UtilizeReservedInstances commons.FieldName = "utilize_reserved_instances"
 )
 
 const (

--- a/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
+++ b/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
@@ -1191,6 +1191,16 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 						Default:      -1,
 						ValidateFunc: validation.IntAtLeast(-1),
 					},
+					string(UtilizeCommitments): {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+					string(UtilizeReservedInstances): {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Default:  true,
+					},
 				},
 			},
 		},
@@ -2511,6 +2521,12 @@ func expandStrategy(data interface{}) (*aws.LaunchSpecStrategy, error) {
 					strategy.SetDrainingTimeout(spotinst.Int(v))
 				}
 			}
+			if v, ok := m[string(UtilizeCommitments)].(bool); ok {
+				strategy.SetUtilizeCommitments(spotinst.Bool(v))
+			}
+			if v, ok := m[string(UtilizeReservedInstances)].(bool); ok {
+				strategy.SetUtilizeReservedInstances(spotinst.Bool(v))
+			}
 		}
 		return strategy, nil
 	}
@@ -2531,6 +2547,12 @@ func flattenStrategy(strategy *aws.LaunchSpecStrategy) []interface{} {
 		}
 		if strategy.DrainingTimeout != nil {
 			result[string(DrainingTimeout)] = spotinst.IntValue(strategy.DrainingTimeout)
+		}
+		if strategy.UtilizeCommitments != nil {
+			result[string(UtilizeCommitments)] = spotinst.BoolValue(strategy.UtilizeCommitments)
+		}
+		if strategy.UtilizeReservedInstances != nil {
+			result[string(UtilizeReservedInstances)] = spotinst.BoolValue(strategy.UtilizeReservedInstances)
 		}
 		if len(result) > 0 {
 			out = append(out, result)


### PR DESCRIPTION
Added support for `utilize_commitments` and `utilize_reserved_instances` under strategy in spotinst_ocean_aws_launch_spec.

# Jira Ticket

Ref: https://spotinst.atlassian.net/browse/SPOTAUT-16900
