### PR TITLE
Added support for `should_utilize_commitments` in `spotinst_ocean_gke_import` under strategy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.193.0 (September, 19 2024)
+ENHANCEMENTS:
+* resource/spotinst_ocean_gke_import: Added support for `should_utilize_commitments` under strategy.
+
 ## 1.192.0 (September, 18 2024)
 NOTES:
 * Added controller v2 reference in ocean resources.

--- a/docs/resources/ocean_gke_import.md
+++ b/docs/resources/ocean_gke_import.md
@@ -195,12 +195,14 @@ The following arguments are supported:
     * `draining_timeout` - (Optional) The draining timeout (in seconds) before terminating the instance. If no draining timeout is defined, the default draining timeout will be used.
     * `provisioning_model` - (Optional) Define the provisioning model of the launched instances. Valid values: `SPOT`, `PREEMPTIBLE`.
     * `preemptible_percentage`- (Optional) Defines the desired preemptible percentage for the cluster.
+    * `should_utilize_commitments`- (Optional) Enable committed use discounts utilization.
 
 ```hcl
   strategy {
     draining_timeout = 50
     provisioning_model = "PREEMPTIBLE"
     preemptible_percentage = 20
+    should_utilize_commitments = true
   }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.368.0
+	github.com/spotinst/spotinst-sdk-go v1.369.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.368.0 h1:CV0w6C6EKK3s4R5B+OkAwx2abt7Kx+Qcd5EvrBsCBog=
-github.com/spotinst/spotinst-sdk-go v1.368.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.369.0 h1:E/39f8GV5FZk4goFBQT8e1O6YUDfn2DVOGCLK5yM16k=
+github.com/spotinst/spotinst-sdk-go v1.369.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/ocean_gke_import_strategy/consts.go
+++ b/spotinst/ocean_gke_import_strategy/consts.go
@@ -3,8 +3,9 @@ package ocean_gke_import_strategy
 import "github.com/spotinst/terraform-provider-spotinst/spotinst/commons"
 
 const (
-	Strategy              commons.FieldName = "strategy"
-	DrainingTimeout       commons.FieldName = "draining_timeout"
-	ProvisioningModel     commons.FieldName = "provisioning_model"
-	PreemptiblePercentage commons.FieldName = "preemptible_percentage"
+	Strategy                 commons.FieldName = "strategy"
+	DrainingTimeout          commons.FieldName = "draining_timeout"
+	ProvisioningModel        commons.FieldName = "provisioning_model"
+	PreemptiblePercentage    commons.FieldName = "preemptible_percentage"
+	ShouldUtilizeCommitments commons.FieldName = "should_utilize_commitments"
 )

--- a/spotinst/ocean_gke_import_strategy/fields_spotinst_ocean_gke_strategy.go
+++ b/spotinst/ocean_gke_import_strategy/fields_spotinst_ocean_gke_strategy.go
@@ -34,6 +34,10 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 						Default:      -1,
 						ValidateFunc: validation.IntAtLeast(-1),
 					},
+					string(ShouldUtilizeCommitments): {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
 				},
 			},
 		},
@@ -104,6 +108,10 @@ func flattenStrategy(strategy *gcp.Strategy) []interface{} {
 		}
 		result[string(PreemptiblePercentage)] = spotinst.IntValue(preemptiblePercentage)
 
+		if strategy.ShouldUtilizeCommitments != nil {
+			result[string(ShouldUtilizeCommitments)] = spotinst.BoolValue(strategy.ShouldUtilizeCommitments)
+		}
+
 		if len(result) > 0 {
 			out = append(out, result)
 		}
@@ -138,6 +146,10 @@ func expandStrategy(data interface{}) (*gcp.Strategy, error) {
 				} else {
 					strategy.SetPreemptiblePercentage(spotinst.Int(v))
 				}
+			}
+
+			if v, ok := m[string(ShouldUtilizeCommitments)].(bool); ok {
+				strategy.SetShouldUtilizeCommitments(spotinst.Bool(v))
 			}
 		}
 


### PR DESCRIPTION
Added support for `should_utilize_commitments` in `spotinst_ocean_gke_import` unrder strategy.

# Jira Ticket

Ref: https://spotinst.atlassian.net/browse/SPOTAUT-19850
