### PR TITLE
fix(ocean/ecs): Fixed `max_vcpu` and `max_memory_gib` fields to accept null.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## 1.200.0 (November, 26 2024)
+BUG FIXES:
+* resource/spotinst_ocean_aws: Fixed `max_vcpu` and `max_memory_gib` fields to accept null.
+* resource/spotinst_ocean_ecs: Fixed `max_vcpu` and `max_memory_gib` fields to accept null.
+
 ## 1.199.0 (November, 21 2024)
 ENHANCEMENTS:
 * resource/spotinst_ocean_aws: Added `reserved_enis` field to support max pods configuration.

--- a/spotinst/ocean_aws_auto_scaling/fields_spotinst_ocean_aws_auto_scaling.go
+++ b/spotinst/ocean_aws_auto_scaling/fields_spotinst_ocean_aws_auto_scaling.go
@@ -321,14 +321,21 @@ func expandOceanAWSAutoScalerResourceLimits(data interface{}) (*aws.AutoScalerRe
 		if list != nil && list[0] != nil {
 			m := list[0].(map[string]interface{})
 
-			if v, ok := m[string(MaxMemoryGIB)].(int); ok && v > 0 {
-				resLimits.SetMaxMemoryGiB(spotinst.Int(v))
+			if v, ok := m[string(MaxMemoryGIB)].(int); ok {
+				if v == 0 {
+					resLimits.SetMaxMemoryGiB(nil)
+				} else {
+					resLimits.SetMaxMemoryGiB(spotinst.Int(v))
+				}
 			}
 
-			if v, ok := m[string(MaxVCPU)].(int); ok && v > 0 {
-				resLimits.SetMaxVCPU(spotinst.Int(v))
+			if v, ok := m[string(MaxVCPU)].(int); ok {
+				if v == 0 {
+					resLimits.SetMaxVCPU(nil)
+				} else {
+					resLimits.SetMaxVCPU(spotinst.Int(v))
+				}
 			}
-
 		}
 		return resLimits, nil
 	}
@@ -429,7 +436,15 @@ func flattenAutoScaleDown(autoScaleDown *aws.AutoScalerDown) []interface{} {
 
 func flattenAutoScaleResourceLimits(autoScalerResourceLimits *aws.AutoScalerResourceLimits) []interface{} {
 	down := make(map[string]interface{})
-	down[string(MaxVCPU)] = spotinst.IntValue(autoScalerResourceLimits.MaxVCPU)
-	down[string(MaxMemoryGIB)] = spotinst.IntValue(autoScalerResourceLimits.MaxMemoryGiB)
+	value := spotinst.Int(0)
+	down[string(MaxVCPU)] = value
+	down[string(MaxMemoryGIB)] = value
+
+	if autoScalerResourceLimits.MaxVCPU != nil {
+		down[string(MaxVCPU)] = spotinst.IntValue(autoScalerResourceLimits.MaxVCPU)
+	}
+	if autoScalerResourceLimits.MaxMemoryGiB != nil {
+		down[string(MaxMemoryGIB)] = spotinst.IntValue(autoScalerResourceLimits.MaxMemoryGiB)
+	}
 	return []interface{}{down}
 }

--- a/spotinst/ocean_ecs_autoscaler/fields_spotinst_ocean_ecs_autoscaler.go
+++ b/spotinst/ocean_ecs_autoscaler/fields_spotinst_ocean_ecs_autoscaler.go
@@ -256,12 +256,20 @@ func expandOceanAWSAutoScalerResourceLimits(data interface{}) (*aws.ECSAutoScale
 		if list != nil && list[0] != nil {
 			m := list[0].(map[string]interface{})
 
-			if v, ok := m[string(MaxMemoryGib)].(int); ok && v > 0 {
-				resLimits.SetMaxMemoryGiB(spotinst.Int(v))
+			if v, ok := m[string(MaxMemoryGib)].(int); ok {
+				if v == 0 {
+					resLimits.SetMaxMemoryGiB(nil)
+				} else {
+					resLimits.SetMaxMemoryGiB(spotinst.Int(v))
+				}
 			}
 
-			if v, ok := m[string(MaxVCpu)].(int); ok && v > 0 {
-				resLimits.SetMaxVCPU(spotinst.Int(v))
+			if v, ok := m[string(MaxVCpu)].(int); ok {
+				if v == 0 {
+					resLimits.SetMaxVCPU(nil)
+				} else {
+					resLimits.SetMaxVCPU(spotinst.Int(v))
+				}
 			}
 
 		}
@@ -338,7 +346,15 @@ func flattenAutoScaleHeadroom(autoScaleHeadroom *aws.ECSAutoScalerHeadroom) []in
 
 func flattenAutoScaleResourceLimits(autoScalerResourceLimits *aws.ECSAutoScalerResourceLimits) []interface{} {
 	down := make(map[string]interface{})
-	down[string(MaxVCpu)] = spotinst.IntValue(autoScalerResourceLimits.MaxVCPU)
-	down[string(MaxMemoryGib)] = spotinst.IntValue(autoScalerResourceLimits.MaxMemoryGiB)
+	value := spotinst.Int(0)
+	down[string(MaxVCpu)] = value
+	down[string(MaxMemoryGib)] = value
+
+	if autoScalerResourceLimits.MaxVCPU != nil {
+		down[string(MaxVCpu)] = spotinst.IntValue(autoScalerResourceLimits.MaxVCPU)
+	}
+	if autoScalerResourceLimits.MaxMemoryGiB != nil {
+		down[string(MaxMemoryGib)] = spotinst.IntValue(autoScalerResourceLimits.MaxMemoryGiB)
+	}
 	return []interface{}{down}
 }


### PR DESCRIPTION
fix(ocean/ecs): Fixed `max_vcpu` and `max_memory_gib` fields to accept null.

https://spotinst.atlassian.net/browse/SI-136