### PR TITLE
feat(stateful_node/azure): added `excluded_vm_sizes` and `spot_size_attributes` fields in `vm_sizes` block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.200.0 (December, 06 2024)
+ENHANCEMENTS:
+* resource/spotinst_stateful_node_azure: Added support for `excluded_vm_sizes` and `spot_size_attributes` fields in `vm_sizes` block.
+
 ## 1.199.3 (December, 03 2024)
 ENHANCEMENTS:
 * Updated crypto/rand package instead of math/rand as part of penetration testing.

--- a/docs/resources/ocean_aws.md
+++ b/docs/resources/ocean_aws.md
@@ -442,5 +442,5 @@ In addition to all arguments above, the following attributes are exported:
 
 Clusters can be imported using the Ocean `id`, e.g.,
 ```hcl
-$ terraform import spotinst_ocean_aws.this o-12345678
+$ terraform import spotinst_ocean_aws.nameOfTheResource o-12345678
 ```

--- a/docs/resources/ocean_aws_launch_spec.md
+++ b/docs/resources/ocean_aws_launch_spec.md
@@ -314,3 +314,12 @@ update_policy {
 
 In addition to all arguments above, the following attributes are exported:
 * `id` - The Virtual Node Group ID.
+
+
+<a id="import"></a>
+## Import
+
+Launch_Specs can be imported using the Launch_Spec `id`, e.g.,
+```hcl
+$ terraform import spotinst_ocean_aws_launch_spec.nameOfTheResource ols-1a2b576
+```

--- a/docs/resources/ocean_ecs.md
+++ b/docs/resources/ocean_ecs.md
@@ -311,5 +311,5 @@ In addition to all arguments above, the following attributes are exported:
 
 Clusters can be imported using the Ocean `id`, e.g.,
 ```hcl
-$ terraform import spotinst_ocean_ecs.this o-12345678
+$ terraform import spotinst_ocean_ecs.nameOfTheResource o-12345678
 ```

--- a/docs/resources/ocean_ecs_launch_spec.md
+++ b/docs/resources/ocean_ecs_launch_spec.md
@@ -159,3 +159,12 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 * `id` - The Spotinst LaunchSpec ID.
+
+
+<a id="import"></a>
+## Import
+
+Launch_Specs can be imported using the Launch_Spec `id`, e.g.,
+```hcl
+$ terraform import spotinst_ocean_ecs_launch_spec.nameOfTheResource ols-1a2345
+```

--- a/docs/resources/stateful_node_azure.md
+++ b/docs/resources/stateful_node_azure.md
@@ -49,6 +49,16 @@ resource "spotinst_stateful_node_azure" "test_stateful_node_azure" {
     od_sizes             = ["standard_ds1_v2", "standard_ds2_v2"]
     spot_sizes           = ["standard_ds1_v2", "standard_ds2_v2"]
     preferred_spot_sizes = ["standard_ds1_v2"]
+    excluded_vm_sizes    = ["standard_ds2_v3"]
+    
+    spot_size_attributes {
+      max_cpu     = 16
+      min_cpu     = 2
+      max_memory  = 48
+      min_memory  = 2
+      max_storage = 1000
+      min_storage = 50
+    }
   }
   zones                = ["1","3"]
   preferred_zone      = "1"
@@ -329,8 +339,16 @@ The following arguments are supported:
 * `os` - (Required, Enum `"Linux", "Windows"`) Type of operating system.
 * `vm_sizes` - (Required) Defines the VM sizes to use when launching VMs.
     * `od_sizes` - (Required) Available On-Demand sizes.
-    * `spot_sizes` - (Required) Available Spot-VM sizes.
+    * `spot_sizes` - (Optional) Available Spot-VM sizes. Required if spotSizeAttributes isn't specified.
     * `preferred_spot_sizes` - (Optional) Prioritize Spot VM sizes when launching Spot VMs for the group. If set, must be a sublist of compute.vmSizes.spotSizes.
+    * `excluded_vm_sizes` - (Optional) Defines the VM sizes to exclude when defining spot types with spotSizeAttributes.
+    * `spot_size_attributes` - (Optional) Defines values and ranges for attributes of the spot sizes to use when launching VMs. Required if spotSizes isn't specified.
+      * `max_cpu` - (Optional) Maximum amount of vCPU units.
+      * `min_cpu` - (Optional) Minimum amount of vCPU units.
+      * `max_memory` - (Optional) Maximum amount of memory in GiB.
+      * `min_memory` - (Optional) Minimum amount of memory in GiB.
+      * `max_storage` - (Optional) Maximum amount of storage in GiB.
+      * `min_storage` - (optional) Minimum amount of storage in GiB.
 * `zones` - (Optional, Enum `"1", "2", "3"`) List of Azure Availability Zones in the defined region. If not defined, Virtual machines will be launched regionally.
 * `preferred_zone` - (Optional, Enum `"1", "2", "3"`) The AZ to prioritize when launching VMs. If no markets are available in the Preferred AZ, VMs are launched in the non-preferred AZ. Must be a sublist of compute.zones.
 * `custom_data` - (Optional) This value will hold the YAML in base64 and will be executed upon VM launch.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.375.0
+	github.com/spotinst/spotinst-sdk-go v1.376.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.375.0 h1:UlSPQiD1yYB4nixntdIkUhlpbVndSLfR5UJKsKfkhgk=
-github.com/spotinst/spotinst-sdk-go v1.375.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.376.0 h1:DL5OI3z7A77oQxRVvXm4GGJaNNd1qyxMNKnk31E4ZVM=
+github.com/spotinst/spotinst-sdk-go v1.376.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/azure_v3/stateful_node_azure_vm_sizes/consts.go
+++ b/spotinst/azure_v3/stateful_node_azure_vm_sizes/consts.go
@@ -7,4 +7,13 @@ const (
 	OnDemandSizes      commons.FieldName = "od_sizes"
 	SpotSizes          commons.FieldName = "spot_sizes"
 	PreferredSpotSizes commons.FieldName = "preferred_spot_sizes"
+	ExcludedVmSizes    commons.FieldName = "excluded_vm_sizes"
+
+	SpotSizeAttributes commons.FieldName = "spot_size_attributes"
+	MaxCpu             commons.FieldName = "max_cpu"
+	MaxMemory          commons.FieldName = "max_memory"
+	MaxStorage         commons.FieldName = "max_storage"
+	MinCpu             commons.FieldName = "min_cpu"
+	MinMemory          commons.FieldName = "min_memory"
+	MinStorage         commons.FieldName = "min_storage"
 )

--- a/spotinst/azure_v3/stateful_node_azure_vm_sizes/fields_spotinst_stateful_node_azure_vm_sizes.go
+++ b/spotinst/azure_v3/stateful_node_azure_vm_sizes/fields_spotinst_stateful_node_azure_vm_sizes.go
@@ -30,7 +30,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 
 					string(SpotSizes): {
 						Type:     schema.TypeList,
-						Required: true,
+						Optional: true,
 						Elem: &schema.Schema{
 							Type: schema.TypeString,
 						},
@@ -41,6 +41,55 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 						Optional: true,
 						Elem: &schema.Schema{
 							Type: schema.TypeString,
+						},
+					},
+
+					string(ExcludedVmSizes): {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+
+					string(SpotSizeAttributes): {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+
+								string(MaxMemory): {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  -1,
+								},
+								string(MaxCpu): {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  -1,
+								},
+								string(MaxStorage): {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  -1,
+								},
+								string(MinMemory): {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  -1,
+								},
+								string(MinCpu): {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  -1,
+								},
+								string(MinStorage): {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  -1,
+								},
+							},
 						},
 					},
 				},
@@ -109,6 +158,14 @@ func flattenStatefulNodeAzureVmSizes(vmSizes *azure.VMSizes) []interface{} {
 		result[string(PreferredSpotSizes)] = spotinst.StringSlice(vmSizes.PreferredSpotSizes)
 	}
 
+	if vmSizes.ExcludedVmSizes != nil {
+		result[string(ExcludedVmSizes)] = spotinst.StringSlice(vmSizes.ExcludedVmSizes)
+	}
+
+	if vmSizes.SpotSizeAttributes != nil {
+		result[string(SpotSizeAttributes)] = flattenSpotSizeAttributes(vmSizes.SpotSizeAttributes)
+	}
+
 	return []interface{}{result}
 }
 
@@ -133,8 +190,10 @@ func expandStatefulNodeAzureVmSizes(data interface{}) (*azure.VMSizes, error) {
 			if err != nil {
 				return nil, err
 			}
-			if spotSizes != nil {
+			if spotSizes != nil && len(spotSizes) > 0 {
 				vmSizes.SetSpotSizes(spotSizes)
+			} else {
+				vmSizes.SetSpotSizes(nil)
 			}
 		}
 
@@ -148,6 +207,32 @@ func expandStatefulNodeAzureVmSizes(data interface{}) (*azure.VMSizes, error) {
 				vmSizes.SetPreferredSpotSizes(prefferedSpotSizes)
 			} else {
 				vmSizes.SetPreferredSpotSizes(nil)
+			}
+		}
+
+		if v, ok := m[string(ExcludedVmSizes)]; ok {
+			excludedVmSizes, err := expandStatefulNodeAzureSizes(v)
+			if err != nil {
+				return nil, err
+			}
+
+			if excludedVmSizes != nil && len(excludedVmSizes) > 0 {
+				vmSizes.SetExcludedVmSizes(excludedVmSizes)
+			} else {
+				vmSizes.SetExcludedVmSizes(nil)
+			}
+		}
+
+		if v, ok := m[string(SpotSizeAttributes)]; ok && v != nil {
+
+			spotSizeAttributes, err := expandSpotSizeAttributes(v)
+			if err != nil {
+				return nil, err
+			}
+			if spotSizeAttributes != nil {
+				vmSizes.SetSpotSizeAttributes(spotSizeAttributes)
+			} else {
+				vmSizes.SetSpotSizeAttributes(nil)
 			}
 		}
 	}
@@ -164,4 +249,110 @@ func expandStatefulNodeAzureSizes(data interface{}) ([]string, error) {
 		}
 	}
 	return result, nil
+}
+
+func expandSpotSizeAttributes(data interface{}) (*azure.SpotSizeAttributes, error) {
+	spotSizeAttributes := &azure.SpotSizeAttributes{}
+	list := data.([]interface{})
+
+	if list == nil || len(list) == 0 {
+		return nil, nil
+	}
+
+	m := list[0].(map[string]interface{})
+
+	if v, ok := m[string(MaxMemory)].(int); ok {
+		// here -1 is used to set MaxMemoryGib field to null when the customer doesn't want to set this param,
+		//as terraform set it 0 for integer type param by default.
+		if v == -1 {
+			spotSizeAttributes.SetMaxMemory(nil)
+		} else {
+			spotSizeAttributes.SetMaxMemory(spotinst.Int(v))
+		}
+	}
+
+	if v, ok := m[string(MaxCpu)].(int); ok {
+		//Here -1 is used to set MaxVCPU field to null when the customer doesn't want to set this param,
+		//as terraform set it 0 for integer type param by default.
+		if v == -1 {
+			spotSizeAttributes.SetMaxCpu(nil)
+		} else {
+			spotSizeAttributes.SetMaxCpu(spotinst.Int(v))
+		}
+	}
+
+	if v, ok := m[string(MaxStorage)].(int); ok {
+		//Here -1 is used to set MaxVCPU field to null when the customer doesn't want to set this param,
+		//as terraform set it 0 for integer type param by default.
+		if v == -1 {
+			spotSizeAttributes.SetMaxStorage(nil)
+		} else {
+			spotSizeAttributes.SetMaxStorage(spotinst.Int(v))
+		}
+	}
+
+	if v, ok := m[string(MinMemory)].(int); ok {
+		// here -1 is used to set MaxMemoryGib field to null when the customer doesn't want to set this param,
+		//as terraform set it 0 for integer type param by default.
+		if v == -1 {
+			spotSizeAttributes.SetMinMemory(nil)
+		} else {
+			spotSizeAttributes.SetMinMemory(spotinst.Int(v))
+		}
+	}
+
+	if v, ok := m[string(MinCpu)].(int); ok {
+		//Here -1 is used to set MaxVCPU field to null when the customer doesn't want to set this param,
+		//as terraform set it 0 for integer type param by default.
+		if v == -1 {
+			spotSizeAttributes.SetMinCpu(nil)
+		} else {
+			spotSizeAttributes.SetMinCpu(spotinst.Int(v))
+		}
+	}
+
+	if v, ok := m[string(MinStorage)].(int); ok {
+		//Here -1 is used to set MaxVCPU field to null when the customer doesn't want to set this param,
+		//as terraform set it 0 for integer type param by default.
+		if v == -1 {
+			spotSizeAttributes.SetMinStorage(nil)
+		} else {
+			spotSizeAttributes.SetMinStorage(spotinst.Int(v))
+		}
+	}
+	return spotSizeAttributes, nil
+}
+
+func flattenSpotSizeAttributes(spotSizeAttributes *azure.SpotSizeAttributes) []interface{} {
+	spotAttributes := make(map[string]interface{})
+	if spotSizeAttributes != nil {
+		value := spotinst.Int(-1)
+		spotAttributes[string(MaxCpu)] = value
+		spotAttributes[string(MaxMemory)] = value
+		spotAttributes[string(MaxStorage)] = value
+		spotAttributes[string(MinCpu)] = value
+		spotAttributes[string(MinMemory)] = value
+		spotAttributes[string(MinStorage)] = value
+
+		if spotSizeAttributes.MaxCpu != nil {
+			spotAttributes[string(MaxCpu)] = spotinst.IntValue(spotSizeAttributes.MaxCpu)
+		}
+		if spotSizeAttributes.MaxMemory != nil {
+			spotAttributes[string(MaxMemory)] = spotinst.IntValue(spotSizeAttributes.MaxMemory)
+		}
+		if spotSizeAttributes.MaxStorage != nil {
+			spotAttributes[string(MaxStorage)] = spotinst.IntValue(spotSizeAttributes.MaxStorage)
+		}
+		if spotSizeAttributes.MinCpu != nil {
+			spotAttributes[string(MinCpu)] = spotinst.IntValue(spotSizeAttributes.MinCpu)
+		}
+		if spotSizeAttributes.MinMemory != nil {
+			spotAttributes[string(MinMemory)] = spotinst.IntValue(spotSizeAttributes.MinMemory)
+		}
+		if spotSizeAttributes.MinStorage != nil {
+			spotAttributes[string(MinStorage)] = spotinst.IntValue(spotSizeAttributes.MinStorage)
+		}
+	}
+
+	return []interface{}{spotAttributes}
 }


### PR DESCRIPTION
Added support for `excluded_vm_sizes` and `spot_size_attributes` fields in `vm_sizes` block.

https://spotinst.atlassian.net/browse/SI-173

https://spotinst.atlassian.net/browse/SI-180