### PR TITLE
feat(ocean/azure): added support for `shutdown_hours` in `scheduling` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.201.0 (December, 11 2024)
+ENHANCEMENTS:
+* resource/spotinst_ocean_aks_np_virtual_node_group: added support for `shutdown_hours` in `scheduling` block.
+
 ## 1.200.0 (December, 06 2024)
 ENHANCEMENTS:
 * resource/spotinst_stateful_node_azure: Added support for `excluded_vm_sizes` and `spot_size_attributes` fields in `vm_sizes` block.

--- a/docs/resources/ocean_aks_np_virtual_node_group.md
+++ b/docs/resources/ocean_aks_np_virtual_node_group.md
@@ -103,6 +103,20 @@ resource "spotinst_ocean_aks_np_virtual_node_group" "example" {
   }
   
   // ----------------------------------------------------------------------------
+  
+  // --- scheduling -------------------------------------------------------------
+  
+  scheduling {
+    shutdown_hours {
+      is_enabled   = true
+      time_windows = [
+        "Fri:15:30-Sat:20:30", 
+        "Sun:08:30-Mon:08:30",
+      ]
+    }
+  }
+  
+  // ----------------------------------------------------------------------------
 }
 ```
 
@@ -166,7 +180,12 @@ The following arguments are supported:
     * `min_disk` - (Optional) Minimum number of data disks available.
     * `vm_types` - (Optional, Enum `"generalPurpose", "memoryOptimized", "computeOptimized", "highPerformanceCompute", "storageOptimized", "GPU"`) The filtered vm types will belong to one of the vm types from this list.
     * `gpu_types` - (Optional, Enum `"nvidia-tesla-v100", "amd-radeon-instinct-mi25", "nvidia-a10", "nvidia-tesla-a100", "nvidia-tesla-k80", "nvidia-tesla-m60", "nvidia-tesla-p100", "nvidia-tesla-p40", "nvidia-tesla-t4", "nvidia-tesla-h100"`) The filtered gpu types will belong to one of the gpu types from this list.
-    <a id="update-policy"></a>
+* `scheduling`- (Optional) An object used to specify times when the virtual node group will turn off all its node pools. Once the shutdown time will be over, the virtual node group will return to its previous state.
+  * `shutdown_hours` - (Optional) An object used to specify times that the nodes in the virtual node group will be stopped.
+    * `is_enabled` - (Optional) Flag to enable or disable the shutdown hours mechanism. When `false`, the mechanism is deactivated, and the virtual node gorup remains in its current state.
+    * `time_windows` - (Optional) The times that the shutdown hours will apply. Required if isEnabled is true.
+
+      <a id="update-policy"></a>
 ## Update Policy
 
 * `update_policy` - (Optional)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.376.0
+	github.com/spotinst/spotinst-sdk-go v1.377.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.376.0 h1:DL5OI3z7A77oQxRVvXm4GGJaNNd1qyxMNKnk31E4ZVM=
-github.com/spotinst/spotinst-sdk-go v1.376.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.377.0 h1:9OL14YtYh8KNtiYy9wJ6dAQkQ1Czf/AILiiIOdgQNL8=
+github.com/spotinst/spotinst-sdk-go v1.377.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/commons/common_ocean_aks_np_virtual_node_group.go
+++ b/spotinst/commons/common_ocean_aks_np_virtual_node_group.go
@@ -116,6 +116,7 @@ func NewVirtualNodeGroupAKSNPWrapper() *VirtualNodeGroupAKSNPWrapper {
 			Strategy:           &azure_np.Strategy{},
 			AutoScale:          &azure_np.AutoScale{},
 			VmSizes:            &azure_np.VmSizes{},
+			Scheduling:         &azure_np.Scheduling{},
 		},
 	}
 }

--- a/spotinst/commons/consts.go
+++ b/spotinst/commons/consts.go
@@ -169,6 +169,7 @@ const (
 
 	OceanAKSNPVirtualNodeGroup                   ResourceAffinity = "Ocean_AKS_NP_Virtual_Node_Group"
 	OceanAKSNPVirtualNodeGroupStrategy           ResourceAffinity = "Ocean_AKS_NP_Virtual_Node_Group_Strategy"
+	OceanAKSNPVirtualNodeGroupScheduling         ResourceAffinity = "Ocean_AKS_NP_Virtual_Node_Group_Scheduling"
 	OceanAKSNPVirtualNodeGroupAutoScale          ResourceAffinity = "Ocean_AKS_NP_Virtual_Node_Group_Auto_Scale"
 	OceanAKSNPVirtualNodeGroupNodeCountLimits    ResourceAffinity = "Ocean_AKS_NP_Virtual_Node_Group_Node_Count_Limits"
 	OceanAKSNPVirtualNodeGroupNodePoolProperties ResourceAffinity = "Ocean_AKS_NP_Virtual_Node_Group_Node_Pool_Properties"

--- a/spotinst/ocean_aks_np_virtual_node_group_scheduling/consts.go
+++ b/spotinst/ocean_aks_np_virtual_node_group_scheduling/consts.go
@@ -1,0 +1,10 @@
+package ocean_aks_np_virtual_node_group_scheduling
+
+import "github.com/spotinst/terraform-provider-spotinst/spotinst/commons"
+
+const (
+	Scheduling             commons.FieldName = "scheduling"
+	ShutdownHours          commons.FieldName = "shutdown_hours"
+	TimeWindows            commons.FieldName = "time_windows"
+	ShutdownHoursIsEnabled commons.FieldName = "is_enabled"
+)

--- a/spotinst/ocean_aks_np_virtual_node_group_scheduling/fields_spotinst_ocean_aks_np_virtual_node_group_scheduling.go
+++ b/spotinst/ocean_aks_np_virtual_node_group_scheduling/fields_spotinst_ocean_aks_np_virtual_node_group_scheduling.go
@@ -1,0 +1,167 @@
+package ocean_aks_np_virtual_node_group_scheduling
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/spotinst/spotinst-sdk-go/service/ocean/providers/azure_np"
+	"github.com/spotinst/spotinst-sdk-go/spotinst"
+	"github.com/spotinst/terraform-provider-spotinst/spotinst/commons"
+)
+
+func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
+
+	fieldsMap[Scheduling] = commons.NewGenericField(
+		commons.OceanAKSNPVirtualNodeGroupScheduling,
+		Scheduling,
+		&schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					string(ShutdownHours): {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								string(ShutdownHoursIsEnabled): {
+									Type:     schema.TypeBool,
+									Optional: true,
+								},
+
+								string(TimeWindows): {
+									Type:     schema.TypeList,
+									Optional: true,
+									Elem:     &schema.Schema{Type: schema.TypeString},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			vngWrapper := resourceObject.(*commons.VirtualNodeGroupAKSNPWrapper)
+			virtualNodeGroup := vngWrapper.GetVirtualNodeGroup()
+			var result []interface{} = nil
+			if virtualNodeGroup != nil && virtualNodeGroup.Scheduling != nil {
+				result = flattenScheduling(virtualNodeGroup.Scheduling)
+			}
+
+			if len(result) > 0 {
+				if err := resourceData.Set(string(Scheduling), result); err != nil {
+					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(Scheduling), err)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			vngWrapper := resourceObject.(*commons.VirtualNodeGroupAKSNPWrapper)
+			virtualNodeGroup := vngWrapper.GetVirtualNodeGroup()
+			var value *azure_np.Scheduling = nil
+			if v, ok := resourceData.GetOkExists(string(Scheduling)); ok {
+				if scheduling, err := expandScheduling(v); err != nil {
+					return err
+				} else {
+					value = scheduling
+				}
+			}
+			virtualNodeGroup.SetScheduling(value)
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			vngWrapper := resourceObject.(*commons.VirtualNodeGroupAKSNPWrapper)
+			virtualNodeGroup := vngWrapper.GetVirtualNodeGroup()
+			var value *azure_np.Scheduling = nil
+			if v, ok := resourceData.GetOk(string(Scheduling)); ok {
+				if scheduling, err := expandScheduling(v); err != nil {
+					return err
+				} else {
+					value = scheduling
+				}
+			}
+			virtualNodeGroup.SetScheduling(value)
+			return nil
+		},
+		nil,
+	)
+}
+
+func flattenScheduling(scheduling *azure_np.Scheduling) []interface{} {
+	var out []interface{}
+
+	if scheduling != nil {
+		result := make(map[string]interface{})
+		if scheduling.ShutdownHours != nil {
+			result[string(ShutdownHours)] = flattenShutdownHours(scheduling.ShutdownHours)
+		}
+		if len(result) > 0 {
+			out = append(out, result)
+		}
+	}
+	return out
+}
+
+func flattenShutdownHours(shutdownHours *azure_np.ShutdownHours) []interface{} {
+	result := make(map[string]interface{})
+	if shutdownHours != nil {
+		result[string(ShutdownHoursIsEnabled)] = spotinst.BoolValue(shutdownHours.IsEnabled)
+		if shutdownHours.TimeWindows != nil {
+			result[string(TimeWindows)] = shutdownHours.TimeWindows
+		}
+	}
+	return []interface{}{result}
+}
+
+func expandScheduling(data interface{}) (*azure_np.Scheduling, error) {
+	scheduling := &azure_np.Scheduling{}
+	if list := data.([]interface{}); len(list) > 0 {
+		if list[0] != nil {
+			m := list[0].(map[string]interface{})
+
+			if v, ok := m[string(ShutdownHours)]; ok {
+				shutdownHours, err := expandShutdownHours(v)
+				if err != nil {
+					return nil, err
+				}
+				if shutdownHours != nil {
+					if scheduling.ShutdownHours == nil {
+						scheduling.SetShutdownHours(&azure_np.ShutdownHours{})
+					}
+					scheduling.SetShutdownHours(shutdownHours)
+				}
+			}
+		}
+		return scheduling, nil
+	}
+	return nil, nil
+}
+
+func expandShutdownHours(data interface{}) (*azure_np.ShutdownHours, error) {
+	shutDownHours := &azure_np.ShutdownHours{}
+	if list := data.([]interface{}); len(list) > 0 && list[0] != nil {
+		m := list[0].(map[string]interface{})
+
+		var isEnabled = spotinst.Bool(false)
+		if v, ok := m[string(ShutdownHoursIsEnabled)].(bool); ok {
+			isEnabled = spotinst.Bool(v)
+		}
+		shutDownHours.SetIsEnabled(isEnabled)
+
+		var timeWindows []string = nil
+		if v, ok := m[string(TimeWindows)].([]interface{}); ok && len(v) > 0 {
+			timeWindowList := make([]string, 0, len(v))
+			for _, timeWindow := range v {
+				if v, ok := timeWindow.(string); ok && len(v) > 0 {
+					timeWindowList = append(timeWindowList, v)
+				}
+			}
+			timeWindows = timeWindowList
+		}
+		shutDownHours.SetTimeWindows(timeWindows)
+
+		return shutDownHours, nil
+	}
+	return nil, nil
+}

--- a/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spotinst/terraform-provider-spotinst/spotinst/ocean_aks_np_virtual_node_group_auto_scale"
 	"github.com/spotinst/terraform-provider-spotinst/spotinst/ocean_aks_np_virtual_node_group_node_count_limits"
 	"github.com/spotinst/terraform-provider-spotinst/spotinst/ocean_aks_np_virtual_node_group_node_pool_properties"
+	"github.com/spotinst/terraform-provider-spotinst/spotinst/ocean_aks_np_virtual_node_group_scheduling"
 	"github.com/spotinst/terraform-provider-spotinst/spotinst/ocean_aks_np_virtual_node_group_strategy"
 	"github.com/spotinst/terraform-provider-spotinst/spotinst/ocean_aks_np_virtual_node_group_vm_sizes"
 )
@@ -46,6 +47,7 @@ func setupOceanAKSNPVirtualNodeGroupResource() {
 	ocean_aks_np_virtual_node_group_node_count_limits.Setup(fieldsMap)
 	ocean_aks_np_virtual_node_group_strategy.Setup(fieldsMap)
 	ocean_aks_np_virtual_node_group_vm_sizes.Setup(fieldsMap)
+	ocean_aks_np_virtual_node_group_scheduling.Setup(fieldsMap)
 
 	commons.OceanAKSNPVirtualNodeGroupResource = commons.NewOceanAKSNPVirtualNodeGroupResource(fieldsMap)
 }

--- a/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group_test.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group_test.go
@@ -632,3 +632,95 @@ resource "` + string(commons.OceanAKSNPVirtualNodeGroupResourceName) + `" "%v" {
 `
 
 // endregion
+
+func TestAccSpotinstOceanAKSNPVirtualNodeGroup_Scheduling(t *testing.T) {
+	vngResourceName := "test-aks-vng"
+	resourceName := createOceanAKSNPVirtualNodeGroupResource(vngResourceName)
+
+	var virtualNodeGroup azure_np.VirtualNodeGroup
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t, "azure") },
+		Providers:    TestAccProviders,
+		CheckDestroy: testOceanAKSNPVirtualNodeGroupDestroy,
+
+		Steps: []resource.TestStep{
+			{
+				Config: createOceanAKSNPVirtualNodeGroupTerraform(&AKSNPVirtualNodeGroupConfigMetadata{vngResourceName: vngResourceName, updateBaselineFields: true}, testSchedulingOceanAKSNPVirtualNodeGroup_Create),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckOceanAKSNPVirtualNodeGroupExists(&virtualNodeGroup, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.0.shutdown_hours.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.0.shutdown_hours.0.is_enabled", "false"),
+				),
+			},
+			{
+				Config: createOceanAKSNPVirtualNodeGroupTerraform(&AKSNPVirtualNodeGroupConfigMetadata{vngResourceName: vngResourceName, updateBaselineFields: true}, testSchedulingOceanAKSNPVirtualNodeGroup_Update),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckOceanAKSNPVirtualNodeGroupExists(&virtualNodeGroup, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.0.shutdown_hours.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.0.shutdown_hours.0.is_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.0.shutdown_hours.0.time_windows.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.0.shutdown_hours.0.time_windows.0", "Sat:08:00-Sun:08:00"),
+				),
+			},
+			{
+				Config: createOceanAKSNPVirtualNodeGroupTerraform(&AKSNPVirtualNodeGroupConfigMetadata{
+					vngResourceName:      vngResourceName,
+					updateBaselineFields: true,
+				}, testSchedulingOceanAKSNPVirtualNodeGroup_EmptyFields),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckOceanAKSNPVirtualNodeGroupExists(&virtualNodeGroup, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testSchedulingOceanAKSNPVirtualNodeGroup_Create = `
+resource "` + string(commons.OceanAKSNPVirtualNodeGroupResourceName) + `" "%v" {
+  provider = "%v"  
+
+  name  = "testVng"
+
+  ocean_id = "o-751eaa33"
+
+  scheduling {
+    shutdown_hours{
+      is_enabled   = false
+    }
+  }
+
+}
+`
+
+const testSchedulingOceanAKSNPVirtualNodeGroup_Update = `
+resource "` + string(commons.OceanAKSNPVirtualNodeGroupResourceName) + `" "%v" {
+  provider = "%v"  
+
+  name  = "testVng"
+
+  ocean_id = "o-751eaa33"
+  scheduling {
+    shutdown_hours{
+      is_enabled   = true
+      time_windows = ["Sat:08:00-Sun:08:00"]
+    }
+  }
+
+}
+`
+
+const testSchedulingOceanAKSNPVirtualNodeGroup_EmptyFields = `
+resource "` + string(commons.OceanAKSNPVirtualNodeGroupResourceName) + `" "%v" {
+  provider = "%v"  
+
+  name  = "testVng"
+
+  ocean_id = "o-751eaa33"
+
+}
+`
+
+//endregion


### PR DESCRIPTION
added support for `shutdown_hours` in `scheduling` block.

https://spotinst.atlassian.net/browse/SI-182