### PR TITLE
feat(ocean/ecs): added `fallback_to_ondemand` field in `strategy` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.203.0 (December, 31 2024)
+ENHANCEMENTS:
+* resource/spotinst_ocean_ecs: added `fallback_to_od` field in `strategy` object.
+
 ## 1.202.0 (December, 18 2024)
 ENHANCEMENTS:
 * resource/spotinst_stateful_node_azure: Added support for `should_revert_to_od` in deallocation config block.

--- a/docs/resources/ocean_ecs.md
+++ b/docs/resources/ocean_ecs.md
@@ -66,6 +66,7 @@ resource "spotinst_ocean_ecs" "example" {
 
     spot_percentage             = 100
     utilize_commitments         = false
+    fallback_to_ondemand        = true
     cluster_orientation {
     availability_vs_cost        = "balanced"
   }
@@ -167,6 +168,7 @@ The following arguments are supported:
 * `ebs_optimized` - (Optional) Enable EBS optimized for cluster. Flag will enable optimized capacity for high bandwidth connectivity to the EB service for non EBS optimized instance types. For instances that are EBS optimized this flag will be ignored.
 * `use_as_template_only` - (Optional, Default: false) launch specification defined on the Ocean object will function only as a template for virtual node groups.
 * `spot_percentage` - (Optional) The percentage of Spot instances that would spin up from the `desired_capacity` number.
+* `fallback_to_ondemand` - (Optional, Default: `true`) If no Spot instance markets are available, enable Ocean to launch On-Demand instances instead.
 * `utilize_commitments` - (Optional, Default false) If savings plans exist, Ocean will utilize them before launching Spot instances.
 * `cluster_orientation`
     * `availability_vs_cost` - (Optional, Default: `balanced`) You can control the approach that Ocean takes while launching nodes by configuring this value. Possible values: `costOriented`,`balanced`,`cheapest`.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.378.0
+	github.com/spotinst/spotinst-sdk-go v1.379.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.378.0 h1:y54fVIeQp97nLcQV43CjdX6QB2aYTj6XWXcdkhbPsCA=
-github.com/spotinst/spotinst-sdk-go v1.378.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.379.0 h1:SSTxecHgH4LSB2OokxnoEA4WZ7Xy4Cu5lAJB7ueOWGk=
+github.com/spotinst/spotinst-sdk-go v1.379.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/ocean_ecs_strategy/consts.go
+++ b/spotinst/ocean_ecs_strategy/consts.go
@@ -9,4 +9,5 @@ const (
 	SpotPercentage           commons.FieldName = "spot_percentage"
 	ClusterOrientation       commons.FieldName = "cluster_orientation"
 	AvailabilityVsCost       commons.FieldName = "availability_vs_cost"
+	FallbackToOnDemand       commons.FieldName = "fallback_to_ondemand"
 )

--- a/spotinst/ocean_ecs_strategy/fields_spotinst_ocean_ecs_strategy.go
+++ b/spotinst/ocean_ecs_strategy/fields_spotinst_ocean_ecs_strategy.go
@@ -257,6 +257,52 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		},
 		nil,
 	)
+
+	fieldsMap[FallbackToOnDemand] = commons.NewGenericField(
+		commons.OceanECSStrategy,
+		FallbackToOnDemand,
+		&schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.ECSClusterWrapper)
+			cluster := clusterWrapper.GetECSCluster()
+			var value *bool = nil
+			if cluster.Strategy != nil && cluster.Strategy.FallbackToOnDemand != nil {
+				value = cluster.Strategy.FallbackToOnDemand
+			}
+			if value != nil {
+				if err := resourceData.Set(string(FallbackToOnDemand), spotinst.BoolValue(value)); err != nil {
+					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(FallbackToOnDemand), err)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.ECSClusterWrapper)
+			cluster := clusterWrapper.GetECSCluster()
+			if v, ok := resourceData.GetOkExists(string(FallbackToOnDemand)); ok && v != nil {
+				ftod := v.(bool)
+				fallback := spotinst.Bool(ftod)
+				cluster.Strategy.SetFallbackToOnDemand(fallback)
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.ECSClusterWrapper)
+			cluster := clusterWrapper.GetECSCluster()
+			var fallback *bool = nil
+			if v, ok := resourceData.GetOkExists(string(FallbackToOnDemand)); ok && v != nil {
+				ftod := v.(bool)
+				fallback = spotinst.Bool(ftod)
+			}
+			cluster.Strategy.SetFallbackToOnDemand(fallback)
+			return nil
+		},
+		nil,
+	)
 }
 func flattenClusterOrientation(clusterOrientation *aws.ECSClusterOrientation) []interface{} {
 	var out []interface{}

--- a/spotinst/resource_spotinst_ocean_ecs_test.go
+++ b/spotinst/resource_spotinst_ocean_ecs_test.go
@@ -619,6 +619,7 @@ func TestAccSpotinstOceanECS_Strategy(t *testing.T) {
 					testCheckOceanECSAttributes(&cluster, name),
 					resource.TestCheckResourceAttr(resourceName, "draining_timeout", "120"),
 					resource.TestCheckResourceAttr(resourceName, "spot_percentage", "100"),
+					resource.TestCheckResourceAttr(resourceName, "fallback_to_ondemand", "true"),
 				),
 			},
 			{
@@ -633,6 +634,7 @@ func TestAccSpotinstOceanECS_Strategy(t *testing.T) {
 					testCheckOceanECSAttributes(&cluster, name),
 					resource.TestCheckResourceAttr(resourceName, "draining_timeout", "240"),
 					resource.TestCheckResourceAttr(resourceName, "spot_percentage", "50"),
+					resource.TestCheckResourceAttr(resourceName, "fallback_to_ondemand", "false"),
 				),
 			},
 			{
@@ -647,6 +649,7 @@ func TestAccSpotinstOceanECS_Strategy(t *testing.T) {
 					testCheckOceanECSAttributes(&cluster, name),
 					resource.TestCheckResourceAttr(resourceName, "draining_timeout", "0"),
 					resource.TestCheckResourceAttr(resourceName, "spot_percentage", "-1"),
+					resource.TestCheckResourceAttr(resourceName, "fallback_to_ondemand", "true"),
 				),
 			},
 		},
@@ -657,6 +660,7 @@ const testStrategy_Create = `
 // --- STRATEGY -----------------
 	draining_timeout = 120
 	spot_percentage  = 100
+	fallback_to_ondemand = true
 // --------------------------------
 `
 
@@ -664,6 +668,7 @@ const testStrategy_Update = `
 // --- STRATEGY -----------------
 	draining_timeout = 240
 	spot_percentage  = 50
+	fallback_to_ondemand = false
 // --------------------------------
 `
 


### PR DESCRIPTION
added support for `fallback_to_ondemand` field in `strategy` object

https://spotinst.atlassian.net/browse/SI-194