### PR TITLE
fix(elastigroup/gcp): 'disk_size_gb' shoud be int and 'disks' is correct schema key

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ $ go build -o terraform-provider-spotinst
 Then, update your `~/.terraformrc` file to point at the location you've built it.
 
 ```hcl
-providers {
-  spotinst = "${GOPATH}/src/github.com/spotinst/terraform-provider-spotinst/terraform-provider-spotinst"
+provider_installation {
+  dev_overrides {
+    "spotinst/spotinst" = "${GOPATH}/src/github.com/spotinst/terraform-provider-spotinst"
+  }
+
+  direct {}
 }
 ```
 

--- a/spotinst/elastigroup_gcp_disk/consts.go
+++ b/spotinst/elastigroup_gcp_disk/consts.go
@@ -3,7 +3,7 @@ package elastigroup_gcp_disk
 import "github.com/spotinst/terraform-provider-spotinst/spotinst/commons"
 
 const (
-	Disk             commons.FieldName = "disk"
+	Disks            commons.FieldName = "disks"
 	AutoDelete       commons.FieldName = "auto_delete"
 	Boot             commons.FieldName = "boot"
 	DeviceName       commons.FieldName = "device_name"

--- a/spotinst/elastigroup_gcp_disk/fields_spotinst_elastigroup_gcp_disk.go
+++ b/spotinst/elastigroup_gcp_disk/fields_spotinst_elastigroup_gcp_disk.go
@@ -38,7 +38,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{
 								string(DiskSizeGB): {
-									Type:     schema.TypeString,
+									Type:     schema.TypeInt,
 									Optional: true,
 								},
 

--- a/spotinst/elastigroup_gcp_disk/fields_spotinst_elastigroup_gcp_disk.go
+++ b/spotinst/elastigroup_gcp_disk/fields_spotinst_elastigroup_gcp_disk.go
@@ -9,9 +9,9 @@ import (
 
 func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 
-	fieldsMap[Disk] = commons.NewGenericField(
+	fieldsMap[Disks] = commons.NewGenericField(
 		commons.ElastigroupGCPDisk,
-		Disk,
+		Disks,
 		&schema.Schema{
 			Type:     schema.TypeSet,
 			Optional: true,
@@ -83,7 +83,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			egWrapper := resourceObject.(*commons.ElastigroupGCPWrapper)
 			elastigroup := egWrapper.GetElastigroup()
-			if v, ok := resourceData.GetOk(string(Disk)); ok {
+			if v, ok := resourceData.GetOk(string(Disks)); ok {
 				if networks, err := expandDisks(v); err != nil {
 					return err
 				} else {
@@ -95,7 +95,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			egWrapper := resourceObject.(*commons.ElastigroupGCPWrapper)
 			elastigroup := egWrapper.GetElastigroup()
-			if v, ok := resourceData.GetOk(string(Disk)); ok {
+			if v, ok := resourceData.GetOk(string(Disks)); ok {
 				if networks, err := expandDisks(v); err != nil {
 					return err
 				} else {

--- a/spotinst/resource_spotinst_elastigroup_gcp_test.go
+++ b/spotinst/resource_spotinst_elastigroup_gcp_test.go
@@ -112,7 +112,7 @@ type GCPGroupConfigMetadata struct {
 	groupName            string
 	instanceTypes        string
 	launchConfig         string
-	disk                 string
+	disks                string
 	strategy             string
 	fieldsToAppend       string
 	updateBaselineFields bool
@@ -138,8 +138,8 @@ func createElastigroupGCPTerraform(gcm *GCPGroupConfigMetadata) string {
 	//	gcm.launchConfig = testLaunchConfigurationGCPGroupConfig_Create
 	//}
 
-	if gcm.disk == "" {
-		gcm.disk = testDiskGCPGroupConfig_Create
+	if gcm.disks == "" {
+		gcm.disks = testDiskGCPGroupConfig_Create
 	}
 
 	if gcm.strategy == "" {
@@ -161,7 +161,7 @@ func createElastigroupGCPTerraform(gcm *GCPGroupConfigMetadata) string {
 			gcm.groupName,
 			gcm.instanceTypes,
 			gcm.launchConfig,
-			gcm.disk,
+			gcm.disks,
 			gcm.strategy,
 			gcm.fieldsToAppend,
 		)
@@ -174,7 +174,7 @@ func createElastigroupGCPTerraform(gcm *GCPGroupConfigMetadata) string {
 			gcm.groupName,
 			gcm.instanceTypes,
 			gcm.launchConfig,
-			gcm.disk,
+			gcm.disks,
 			gcm.strategy,
 			gcm.fieldsToAppend,
 		)
@@ -569,57 +569,57 @@ func TestAccSpotinstElastigroupGCP_Disk(t *testing.T) {
 				ResourceName: resourceName,
 				Config: createElastigroupGCPTerraform(&GCPGroupConfigMetadata{
 					groupName: groupName,
-					disk:      testDiskGCPGroupConfig_Create,
+					disks:     testDiskGCPGroupConfig_Create,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckElastigroupGCPExists(&group, resourceName),
 					testCheckElastigroupGCPAttributes(&group, groupName),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.auto_delete", "false"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.boot", "false"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.device_name", "tf-test-device"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.interface", "SCSI"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.mode", "READ_WRITE"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.source", "fake-source"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.type", "PERSISTENT"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.initialize_params.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.initialize_params.0.disk_size_gb", "20"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.initialize_params.0.disk_type", "pd-standard"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.initialize_params.0.source_image", "https://www.googleapis.com/compute/v1/projects/spotinst-labs/global/images/test-image-1"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.auto_delete", "false"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.boot", "false"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.device_name", "tf-test-device"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.interface", "SCSI"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.mode", "READ_WRITE"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.source", "fake-source"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.type", "PERSISTENT"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.initialize_params.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.initialize_params.0.disk_size_gb", "20"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.initialize_params.0.disk_type", "pd-standard"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.initialize_params.0.source_image", "https://www.googleapis.com/compute/v1/projects/spotinst-labs/global/images/test-image-1"),
 				),
 			},
 			{
 				ResourceName: resourceName,
 				Config: createElastigroupGCPTerraform(&GCPGroupConfigMetadata{
 					groupName: groupName,
-					disk:      testDiskGCPGroupConfig_Update,
+					disks:     testDiskGCPGroupConfig_Update,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckElastigroupGCPExists(&group, resourceName),
 					testCheckElastigroupGCPAttributes(&group, groupName),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.auto_delete", "true"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.boot", "true"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.device_name", "tf-test-device-updated"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.interface", "NVM"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.mode", "READ_ONLY"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.source", "fake-source-updated"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.type", "SCRATCH"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.initialize_params.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.initialize_params.0.disk_size_gb", "30"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.initialize_params.0.disk_type", "local-ssd"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.initialize_params.0.source_image", "https://www.googleapis.com/compute/v1/projects/spotinst-labs/global/images/test-image-2"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.auto_delete", "true"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.boot", "true"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.device_name", "tf-test-device-updated"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.interface", "NVM"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.mode", "READ_ONLY"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.source", "fake-source-updated"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.type", "SCRATCH"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.initialize_params.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.initialize_params.0.disk_size_gb", "30"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.initialize_params.0.disk_type", "local-ssd"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.initialize_params.0.source_image", "https://www.googleapis.com/compute/v1/projects/spotinst-labs/global/images/test-image-2"),
 				),
 			},
 			{
 				ResourceName: resourceName,
 				Config: createElastigroupGCPTerraform(&GCPGroupConfigMetadata{
 					groupName: groupName,
-					disk:      testDiskGCPGroupConfig_EmptyFields,
+					disks:     testDiskGCPGroupConfig_EmptyFields,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckElastigroupGCPExists(&group, resourceName),
 					testCheckElastigroupGCPAttributes(&group, groupName),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.initialize_params.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "disk.0.initialize_params.0.source_image", "https://www.googleapis.com/compute/v1/projects/spotinst-labs/global/images/test-image-2"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.initialize_params.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "disks.0.initialize_params.0.source_image", "https://www.googleapis.com/compute/v1/projects/spotinst-labs/global/images/test-image-2"),
 				),
 			},
 		},
@@ -628,7 +628,7 @@ func TestAccSpotinstElastigroupGCP_Disk(t *testing.T) {
 
 const testDiskGCPGroupConfig_Create = `
  // --- DISK ------------------------
-  disk {
+  disks {
     auto_delete = false
     boot = false
     device_name = "tf-test-device"
@@ -648,7 +648,7 @@ const testDiskGCPGroupConfig_Create = `
 
 const testDiskGCPGroupConfig_Update = `
  // --- DISK ------------------------
-  disk {
+  disks {
     auto_delete = true
     boot = true
     device_name = "tf-test-device-updated"
@@ -660,7 +660,7 @@ const testDiskGCPGroupConfig_Update = `
     initialize_params {
 			disk_size_gb = 30
 			disk_type = "local-ssd"
-      source_image = "https://www.googleapis.com/compute/v1/projects/spotinst-labs/global/images/test-image-2"
+			source_image = "https://www.googleapis.com/compute/v1/projects/spotinst-labs/global/images/test-image-2"
 		}
   }
  // ---------------------------------
@@ -668,7 +668,7 @@ const testDiskGCPGroupConfig_Update = `
 
 const testDiskGCPGroupConfig_EmptyFields = `
  // --- DISK ------------------------
-  disk {
+  disks {
     initialize_params {
 			source_image = "https://www.googleapis.com/compute/v1/projects/spotinst-labs/global/images/test-image-2"
 		}


### PR DESCRIPTION
* update README.md for provider development dbe65070e5858b410c5384879e4b08edd15c35c5
  * related: https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers
* disk_size_gb should be int 132f499dc80efcc3738096d138b0d134cc5d6449
  * see: https://github.com/spotinst/terraform-provider-spotinst/blob/v1.207.0/spotinst/elastigroup_gcp_disk/fields_spotinst_elastigroup_gcp_disk.go#L171
  * refs: https://docs.spot.io/api/#tag/Elastigroup-GCP/operation/elastigroupGcpCreate
* fix schema key from `disk` to `disks` 71e3bd6d1df8b9c9284ddc581da286dda610562d
  * example shows `disks` https://registry.terraform.io/providers/spotinst/spotinst/latest/docs/resources/elastigroup_gcp#disks-1
  * refs: https://docs.spot.io/api/#tag/Elastigroup-GCP/operation/elastigroupGcpCreate
  
  
- [x] make test at local