### PR TITLE
feat(elastigroup/azure): added `encryption_at_host` field in `securiy` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 1.217.0 (May, 02 2025)
+## 1.217.0 (May, 01 2025)
 ENHANCEMENTS:
 * resource/spotinst_elastigroup_azure_v3: Added support for `encryption_at_host` field in `security` object.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.217.0 (May, 02 2025)
+ENHANCEMENTS:
+* resource/spotinst_elastigroup_azure_v3: Added support for `encryption_at_host` field in `security` object.
+
 ## 1.216.2 (April, 23, 2025)
 BUG FIX:
 * resource/spotinst_ocean_aws_launch_spec: Fixed `no_Device` field to accept empty string inside `block_device_mappings` object.

--- a/docs/resources/elastigroup_azure.md
+++ b/docs/resources/elastigroup_azure.md
@@ -168,6 +168,7 @@ resource "spotinst_elastigroup_azure_v3" "test_azure_group" {
     secure_boot_enabled = false
     vtpm_enabled = false
     confidential_os_disk_encryption = false
+    encryption_at_host = false
   }
 
   // --- LOGIN ---------------------------------------------------------
@@ -269,10 +270,11 @@ The following arguments are supported:
 ## Security
 
 * `security` - (Optional) Specifies the Security related profile settings for the virtual machine.
-  * `confidential_os_disk_encryption` - Confidential disk encryption binds the disk encryption keys to the VM's TPM, ensuring VM-only access. The security type must be "ConfidentialVM" to enable defining this preference as “true”.
-  * `secure_boot_enabled` - Specifies whether secure boot should be enabled on the virtual machine.
+  * `confidential_os_disk_encryption` - (Optional, Default: false) Confidential disk encryption binds the disk encryption keys to the VM's TPM, ensuring VM-only access. The security type must be "ConfidentialVM" to enable defining this preference as “true”.
+  * `secure_boot_enabled` - (Optional, Default: false) Specifies whether secure boot should be enabled on the virtual machine.
   * `security_type` - Security type refers to the different security features of a virtual machine. Security features like Trusted launch virtual machines help to improve the security of Azure generation 2 virtual machines. Valid values: `"Standard"`, `"TrustedLaunch"`, `"ConfidentialVM"`
-  * `vtpm_enabled` - Specifies whether vTPM should be enabled on the virtual machine.
+  * `vtpm_enabled` - (Optional) Specifies whether vTPM should be enabled on the virtual machine.
+  * `encryption_at_host` - (Optional, Default: false) Enables the Host Encryption for the virtual machine. The Encryption at host will be disabled unless this property is set to true for the resource.
 
 <a id="proximity_placement_groups"></a>
 ## Proximity Placement Groups

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.390.0
+	github.com/spotinst/spotinst-sdk-go v1.391.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0
 github.com/skeema/knownhosts v1.3.0/go.mod h1:sPINvnADmT/qYH1kfv+ePMmOBTH6Tbl7b5LvTDjFK7M=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.390.0 h1:kKMkKwccXDePbnn87WbLvB75EVjZzoq9Al+haXz18F4=
-github.com/spotinst/spotinst-sdk-go v1.390.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.391.0 h1:ZAstVlnGa4zdMvr9Qk5/Q8GyOAfDHvKxI1zYuvq7wZc=
+github.com/spotinst/spotinst-sdk-go v1.391.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/azure_v3/elastigroup_azure_launchspecification/consts.go
+++ b/spotinst/azure_v3/elastigroup_azure_launchspecification/consts.go
@@ -49,6 +49,7 @@ const (
 	SecurityType                 commons.FieldName = "security_type"
 	VTpmEnabled                  commons.FieldName = "vtpm_enabled"
 	ConfidentialOsDiskEncryption commons.FieldName = "confidential_os_disk_encryption"
+	EncryptionAtHost             commons.FieldName = "encryption_at_host"
 )
 
 const (

--- a/spotinst/azure_v3/elastigroup_azure_launchspecification/fields_spotinst_elastigroup_azure_launchspecification.go
+++ b/spotinst/azure_v3/elastigroup_azure_launchspecification/fields_spotinst_elastigroup_azure_launchspecification.go
@@ -611,6 +611,10 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 						Type:     schema.TypeBool,
 						Optional: true,
 					},
+					string(EncryptionAtHost): {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
 				},
 			},
 		},
@@ -873,6 +877,7 @@ func flattenSecurity(secure *azurev3.Security) interface{} {
 	security[string(SecurityType)] = spotinst.StringValue(secure.SecurityType)
 	security[string(VTpmEnabled)] = spotinst.BoolValue(secure.VTpmEnabled)
 	security[string(ConfidentialOsDiskEncryption)] = spotinst.BoolValue(secure.ConfidentialOsDiskEncryption)
+	security[string(EncryptionAtHost)] = spotinst.BoolValue(secure.EncryptionAtHost)
 
 	return []interface{}{security}
 }
@@ -895,6 +900,9 @@ func expandSecurity(data interface{}) (*azurev3.Security, error) {
 			}
 			if v, ok := m[string(ConfidentialOsDiskEncryption)].(bool); ok {
 				security.SetConfidentialOsDiskEncryption(spotinst.Bool(v))
+			}
+			if v, ok := m[string(EncryptionAtHost)].(bool); ok {
+				security.SetEncryptionAtHost(spotinst.Bool(v))
 			}
 		}
 		return security, nil


### PR DESCRIPTION
added `encryption_at_host` field in `security` object

https://spotinst.atlassian.net/browse/SI-330

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
