### PR TITLE
feat(elastigroup/azure): added `excluded_vm_sizes` and `spot_size_Attributes` in `vm_sizes` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.218.0 (May, 02 2025)
+ENHANCEMENTS:
+* resource/spotinst_elastigroup_azure_v3: Added support for `excluded_vm_sizes` and `spot_size_attributes` in `vm_sizes` object.
+
 ## 1.217.0 (May, 01 2025)
 ENHANCEMENTS:
 * resource/spotinst_elastigroup_azure_v3: Added support for `encryption_at_host` field in `security` object.

--- a/docs/resources/elastigroup_azure.md
+++ b/docs/resources/elastigroup_azure.md
@@ -33,6 +33,16 @@ resource "spotinst_elastigroup_azure_v3" "test_azure_group" {
        od_sizes   = ["standard_a1_v1","standard_a1_v2"]
        spot_sizes = ["standard_a1_v1","standard_a1_v2"]
        preferred_spot_sizes = ["standard_a1_v2"]
+       excluded_vm_sizes    = ["standard_ds2_v3"]
+    
+       spot_size_attributes {
+          max_cpu     = 16
+          min_cpu     = 2
+          max_memory  = 64
+          min_memory  = 8
+          max_storage = 512
+          min_storage = 32
+       }
    }
   // -------------------------------------------------------------------
 

--- a/docs/resources/elastigroup_azure.md
+++ b/docs/resources/elastigroup_azure.md
@@ -244,8 +244,16 @@ The following arguments are supported:
     * `value` - (Required) Tag Value for Vms in Elastigroup.
 * `vm_sizes` - (Required) Sizes of On-Demand and Low-Priority VMs.
     * `od_sizes` - (Required) Available On-Demand sizes
-    * `spot_sizes` - (Required) Available Low-Priority sizes.
+    * `spot_sizes` - (Optional) Available Low-Priority sizes.
     * `preferred_spot_sizes` -- (Optional) Prioritize Spot VM sizes when launching Spot VMs for the group. Must be a sublist of `spot_sizes`.
+    * `excluded_vm_sizes` - (Optional) Exclude these spot VM sizes when using attribute-based VM sizes.
+    * `spot_size_attributes` - (Optional) The values and ranges for spot size attributes when launching VMs. Required if spotSizes isn't specified.
+        * `max_cpu` - (Optional) Maximum instance CPU units.
+        * `min_cpu` - (Optional) Minimum instance CPU units.
+        * `max_memory` - (Optional) Maximum amount of memory in GiB.
+        * `min_memory` - (Optional) Minimum amount of memory in GiB.
+        * `max_storage` - (Optional) Maximum amount of storage in GiB.
+        * `min_storage` - (optional) Minimum amount of storage in GiB.
 
 <a id="health"></a>
 ## Health

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.391.0
+	github.com/spotinst/spotinst-sdk-go v1.392.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0
 github.com/skeema/knownhosts v1.3.0/go.mod h1:sPINvnADmT/qYH1kfv+ePMmOBTH6Tbl7b5LvTDjFK7M=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.391.0 h1:ZAstVlnGa4zdMvr9Qk5/Q8GyOAfDHvKxI1zYuvq7wZc=
-github.com/spotinst/spotinst-sdk-go v1.391.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.392.0 h1:3qpMJg4a1DwMHt8avby9NvSeIDlvrTTIk3aN0lXW7Ig=
+github.com/spotinst/spotinst-sdk-go v1.392.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/azure_v3/elastigroup_azure_vm_sizes/consts.go
+++ b/spotinst/azure_v3/elastigroup_azure_vm_sizes/consts.go
@@ -14,7 +14,6 @@ const (
 	ExcludedVmSizes    commons.FieldName = "excluded_vm_sizes"
 
 	SpotSizeAttributes commons.FieldName = "spot_size_attributes"
-	CPUArchitecture    commons.FieldName = "cpu_architecture"
 	MaxCpu             commons.FieldName = "max_cpu"
 	MaxMemory          commons.FieldName = "max_memory"
 	MaxStorage         commons.FieldName = "max_storage"

--- a/spotinst/azure_v3/elastigroup_azure_vm_sizes/consts.go
+++ b/spotinst/azure_v3/elastigroup_azure_vm_sizes/consts.go
@@ -11,4 +11,14 @@ const (
 	OnDemandSizes      commons.FieldName = "od_sizes"
 	SpotSizes          commons.FieldName = "spot_sizes"
 	PreferredSpotSizes commons.FieldName = "preferred_spot_sizes"
+	ExcludedVmSizes    commons.FieldName = "excluded_vm_sizes"
+
+	SpotSizeAttributes commons.FieldName = "spot_size_attributes"
+	CPUArchitecture    commons.FieldName = "cpu_architecture"
+	MaxCpu             commons.FieldName = "max_cpu"
+	MaxMemory          commons.FieldName = "max_memory"
+	MaxStorage         commons.FieldName = "max_storage"
+	MinCpu             commons.FieldName = "min_cpu"
+	MinMemory          commons.FieldName = "min_memory"
+	MinStorage         commons.FieldName = "min_storage"
 )

--- a/spotinst/azure_v3/elastigroup_azure_vm_sizes/fields_spotinst_elastigroup_azure_vm_sizes.go
+++ b/spotinst/azure_v3/elastigroup_azure_vm_sizes/fields_spotinst_elastigroup_azure_vm_sizes.go
@@ -2,6 +2,7 @@ package elastigroup_azure_vm_sizes
 
 import (
 	"fmt"
+	"github.com/spotinst/spotinst-sdk-go/spotinst"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	azurev3 "github.com/spotinst/spotinst-sdk-go/service/elastigroup/providers/azure/v3"
@@ -40,6 +41,60 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 						Optional: true,
 						Elem: &schema.Schema{
 							Type: schema.TypeString,
+						},
+					},
+
+					string(ExcludedVmSizes): {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+
+					string(SpotSizeAttributes): {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+
+								string(CPUArchitecture): {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+
+								string(MaxMemory): {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  -1,
+								},
+								string(MaxCpu): {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  -1,
+								},
+								string(MaxStorage): {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  -1,
+								},
+								string(MinMemory): {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  -1,
+								},
+								string(MinCpu): {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  -1,
+								},
+								string(MinStorage): {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  -1,
+								},
+							},
 						},
 					},
 				},
@@ -104,6 +159,15 @@ func flattenAzureGroupSizes(vmSizes *azurev3.VMSizes) []interface{} {
 	if len(vmSizes.PreferredSpotSizes) > 0 {
 		result[string(PreferredSpotSizes)] = vmSizes.PreferredSpotSizes
 	}
+
+	if len(vmSizes.ExcludedVmSizes) > 0 {
+		result[string(ExcludedVmSizes)] = vmSizes.ExcludedVmSizes
+	}
+
+	if vmSizes.SpotSizeAttributes != nil {
+		result[string(SpotSizeAttributes)] = flattenSpotSizeAttributes(vmSizes.SpotSizeAttributes)
+	}
+
 	return []interface{}{result}
 }
 
@@ -143,6 +207,32 @@ func expandAzureGroupSizes(data interface{}) (*azurev3.VMSizes, error) {
 			}
 		}
 
+		if v, ok := m[string(ExcludedVmSizes)]; ok {
+			excludedVmSizes, err := expandSizes(v)
+			if err != nil {
+				return nil, err
+			}
+
+			if excludedVmSizes != nil && len(excludedVmSizes) > 0 {
+				vmSizes.SetExcludedVmSizes(excludedVmSizes)
+			} else {
+				vmSizes.SetExcludedVmSizes(nil)
+			}
+		}
+
+		if v, ok := m[string(SpotSizeAttributes)]; ok && v != nil {
+
+			spotSizeAttributes, err := expandSpotSizeAttributes(v)
+			if err != nil {
+				return nil, err
+			}
+			if spotSizeAttributes != nil {
+				vmSizes.SetSpotSizeAttributes(spotSizeAttributes)
+			} else {
+				vmSizes.SetSpotSizeAttributes(nil)
+			}
+		}
+
 	}
 	return vmSizes, nil
 }
@@ -157,4 +247,117 @@ func expandSizes(data interface{}) ([]string, error) {
 		}
 	}
 	return result, nil
+}
+
+func expandSpotSizeAttributes(data interface{}) (*azurev3.SpotSizeAttributes, error) {
+	spotSizeAttributes := &azurev3.SpotSizeAttributes{}
+	list := data.([]interface{})
+
+	if list == nil || len(list) == 0 {
+		return nil, nil
+	}
+
+	m := list[0].(map[string]interface{})
+
+	if v, ok := m[string(MaxMemory)].(int); ok {
+		// here -1 is used to set MaxMemoryGib field to null when the customer doesn't want to set this param,
+		//as terraform set it 0 for integer type param by default.
+		if v == -1 {
+			spotSizeAttributes.SetMaxMemory(nil)
+		} else {
+			spotSizeAttributes.SetMaxMemory(spotinst.Int(v))
+		}
+	}
+
+	if v, ok := m[string(MaxCpu)].(int); ok {
+		//Here -1 is used to set MaxVCPU field to null when the customer doesn't want to set this param,
+		//as terraform set it 0 for integer type param by default.
+		if v == -1 {
+			spotSizeAttributes.SetMaxCpu(nil)
+		} else {
+			spotSizeAttributes.SetMaxCpu(spotinst.Int(v))
+		}
+	}
+
+	if v, ok := m[string(MaxStorage)].(int); ok {
+		//Here -1 is used to set MaxVCPU field to null when the customer doesn't want to set this param,
+		//as terraform set it 0 for integer type param by default.
+		if v == -1 {
+			spotSizeAttributes.SetMaxStorage(nil)
+		} else {
+			spotSizeAttributes.SetMaxStorage(spotinst.Int(v))
+		}
+	}
+
+	if v, ok := m[string(MinMemory)].(int); ok {
+		// here -1 is used to set MaxMemoryGib field to null when the customer doesn't want to set this param,
+		//as terraform set it 0 for integer type param by default.
+		if v == -1 {
+			spotSizeAttributes.SetMinMemory(nil)
+		} else {
+			spotSizeAttributes.SetMinMemory(spotinst.Int(v))
+		}
+	}
+
+	if v, ok := m[string(MinCpu)].(int); ok {
+		//Here -1 is used to set MaxVCPU field to null when the customer doesn't want to set this param,
+		//as terraform set it 0 for integer type param by default.
+		if v == -1 {
+			spotSizeAttributes.SetMinCpu(nil)
+		} else {
+			spotSizeAttributes.SetMinCpu(spotinst.Int(v))
+		}
+	}
+
+	if v, ok := m[string(MinStorage)].(int); ok {
+		//Here -1 is used to set MaxVCPU field to null when the customer doesn't want to set this param,
+		//as terraform set it 0 for integer type param by default.
+		if v == -1 {
+			spotSizeAttributes.SetMinStorage(nil)
+		} else {
+			spotSizeAttributes.SetMinStorage(spotinst.Int(v))
+		}
+	}
+
+	if v, ok := m[string(CPUArchitecture)].(string); ok && v != "" {
+		spotSizeAttributes.SetCPUArchitecture(spotinst.String(v))
+	}
+	return spotSizeAttributes, nil
+}
+
+func flattenSpotSizeAttributes(spotSizeAttributes *azurev3.SpotSizeAttributes) []interface{} {
+	spotAttributes := make(map[string]interface{})
+	if spotSizeAttributes != nil {
+		value := spotinst.Int(-1)
+		spotAttributes[string(MaxCpu)] = value
+		spotAttributes[string(MaxMemory)] = value
+		spotAttributes[string(MaxStorage)] = value
+		spotAttributes[string(MinCpu)] = value
+		spotAttributes[string(MinMemory)] = value
+		spotAttributes[string(MinStorage)] = value
+
+		if spotSizeAttributes.MaxCpu != nil {
+			spotAttributes[string(MaxCpu)] = spotinst.IntValue(spotSizeAttributes.MaxCpu)
+		}
+		if spotSizeAttributes.MaxMemory != nil {
+			spotAttributes[string(MaxMemory)] = spotinst.IntValue(spotSizeAttributes.MaxMemory)
+		}
+		if spotSizeAttributes.MaxStorage != nil {
+			spotAttributes[string(MaxStorage)] = spotinst.IntValue(spotSizeAttributes.MaxStorage)
+		}
+		if spotSizeAttributes.MinCpu != nil {
+			spotAttributes[string(MinCpu)] = spotinst.IntValue(spotSizeAttributes.MinCpu)
+		}
+		if spotSizeAttributes.MinMemory != nil {
+			spotAttributes[string(MinMemory)] = spotinst.IntValue(spotSizeAttributes.MinMemory)
+		}
+		if spotSizeAttributes.MinStorage != nil {
+			spotAttributes[string(MinStorage)] = spotinst.IntValue(spotSizeAttributes.MinStorage)
+		}
+		if spotSizeAttributes.CPUArchitecture != nil {
+			spotAttributes[string(CPUArchitecture)] = spotinst.StringValue(spotSizeAttributes.CPUArchitecture)
+		}
+	}
+
+	return []interface{}{spotAttributes}
 }

--- a/spotinst/azure_v3/stateful_node_azure_vm_sizes/fields_spotinst_stateful_node_azure_vm_sizes.go
+++ b/spotinst/azure_v3/stateful_node_azure_vm_sizes/fields_spotinst_stateful_node_azure_vm_sizes.go
@@ -12,7 +12,7 @@ import (
 func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 
 	fieldsMap[VmSizes] = commons.NewGenericField(
-		commons.ElastigroupAzureVMSizes,
+		commons.StatefulNodeAzureVMSizes,
 		VmSizes,
 		&schema.Schema{
 			Type:     schema.TypeList,

--- a/spotinst/resource_spotinst_elastigroup_azure_v3_test.go
+++ b/spotinst/resource_spotinst_elastigroup_azure_v3_test.go
@@ -559,8 +559,13 @@ func TestAccSpotinstElastigroupAzureV3_VMSizes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "vm_sizes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vm_sizes.0.od_sizes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vm_sizes.0.od_sizes.0", "standard_a1_v2"),
-					resource.TestCheckResourceAttr(resourceName, "vm_sizes.0.spot_sizes.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "vm_sizes.0.spot_sizes.0", "standard_a1_v2"),
+					resource.TestCheckResourceAttr(resourceName, "vm_sizes.0.spot_size_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vm_sizes.0.spot_size_attributes.0.min_cpu", "2"),
+					resource.TestCheckResourceAttr(resourceName, "vm_sizes.0.spot_size_attributes.0.max_cpu", "100"),
+					resource.TestCheckResourceAttr(resourceName, "vm_sizes.0.spot_size_attributes.0.min_memory", "8"),
+					resource.TestCheckResourceAttr(resourceName, "vm_sizes.0.spot_size_attributes.0.max_memory", "64"),
+					resource.TestCheckResourceAttr(resourceName, "vm_sizes.0.spot_size_attributes.0.min_storage", "32"),
+					resource.TestCheckResourceAttr(resourceName, "vm_sizes.0.spot_size_attributes.0.max_storage", "1024"),
 				),
 			},
 		},
@@ -580,7 +585,14 @@ const testAzureV3VMSizesGroupConfig_Update = `
 // --- VM SIZES --------------------------------
    vm_sizes{  
      od_sizes = ["standard_a1_v2"]
-     spot_sizes = ["standard_a1_v2"]
+     spot_size_attributes {
+		min_cpu = "2"
+		max_cpu = "100"
+		min_memory = "8"
+		max_memory = "64"
+		min_storage = "32"
+		max_storage = "1024"
+	}
    }
 // ---------------------------------------------
 `


### PR DESCRIPTION
https://spotinst.atlassian.net/browse/SI-327

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
