### PR TITLE
feat(ocean/aws): added support for `startup_taints` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## 1.219.0 (May, 08 2025)
+ENHANCEMENTS:
+* resource/spotinst_ocean_aws: Added support for `startup_taints` object.
+* resource/spotinst_ocean_aws_launch_spec: Added support for `startup_taints` object.
+
 ## 1.218.1 (May, 05 2024)
 BUG FIX:
 * resource/spotinst_stateful_node_azure: Fixed `managed_service_identities` object to allow user to update the fields.

--- a/docs/resources/ocean_aws.md
+++ b/docs/resources/ocean_aws.md
@@ -125,7 +125,13 @@ resource "spotinst_ocean_aws" "example" {
     http_tokens = "required"
     http_put_response_hop_limit = 10
   }
-  
+
+  startup_taints {
+    key    = "example-key"
+    value  = "example-value"
+    effect = "NoSchedule"
+  }
+
   block_device_mappings {
     device_name = "/dev/xvda"
     ebs {
@@ -257,6 +263,10 @@ The following arguments are supported:
             * `id` - (Required) The identifier of The S3 data integration to export the logs to.
 * `resource_tag_specification` - (Optional) Specify which resources should be tagged with Virtual Node Group tags or Ocean tags. If tags are set on the VNG, the resources will be tagged with the VNG tags; otherwise, they will be tagged with the Ocean tags.
     * `should_tag_volumes` - (Optional) Specify if Volume resources will be tagged with Virtual Node Group tags or Ocean tags.
+* `startup_taints` - (Optional) Temporary taints applied to a node during its initialization phase. For a startup taint to work, it must also be set as a regular taint in the userData for the cluster.
+  * `key` - (Optional) Set startup taint key.
+  * `value` - (Optional) Set startup taint value.
+  * `effect` - (Optional) Set startup taint effect.
 ## Auto Scaler
 * `autoscaler` - (Optional) Describes the Ocean Kubernetes Auto Scaler.
     * `autoscale_is_enabled` - (Optional, Default: `true`) Enable the Ocean Kubernetes Auto Scaler.

--- a/docs/resources/ocean_aws_launch_spec.md
+++ b/docs/resources/ocean_aws_launch_spec.md
@@ -61,6 +61,12 @@ resource "spotinst_ocean_aws_launch_spec" "example" {
     effect = "NoExecute"
   }
 
+  startup_taints {
+    key    = "another-key"
+    value  = "another-value"
+    effect = "NoSchedule"
+  }
+
   autoscale_headrooms_automatic {
     auto_headroom_percentage = 5
   }
@@ -208,6 +214,10 @@ The following arguments are supported:
     * `key` - (Required) The taint key.
     * `value` - (Required) The taint value.
     * `effect` - (Required) The effect of the taint. Valid values: `"NoSchedule"`, `"PreferNoSchedule"`, `"NoExecute"`.
+* `startup_taints` - (Optional) Temporary taints applied to a node during its initialization phase. For a startup taint to work, it must also be set as a regular taint in the userData for the cluster.
+    * `key` - (Optional) Set startup taint key.
+    * `value` - (Optional) Set startup taint value.
+    * `effect` - (Optional) Set startup taint effect.
 * `elastic_ip_pool` - (Optional) Assign an Elastic IP to the instances spun by the Virtual Node Group. Can be null.
     * `tag_selector` - (Optional) A key-value pair, which defines an Elastic IP from the customer pool. Can be null.
         * `tag_key` - (Required) Elastic IP tag key. The Virtual Node Group will consider all Elastic IPs tagged with this tag as a part of the Elastic IP pool to use.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.392.0
+	github.com/spotinst/spotinst-sdk-go v1.393.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0
 github.com/skeema/knownhosts v1.3.0/go.mod h1:sPINvnADmT/qYH1kfv+ePMmOBTH6Tbl7b5LvTDjFK7M=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.392.0 h1:3qpMJg4a1DwMHt8avby9NvSeIDlvrTTIk3aN0lXW7Ig=
-github.com/spotinst/spotinst-sdk-go v1.392.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.393.0 h1:tudLImp+e8Y0sgzQGOXFZD5Eq9h039tTmB9wc+3l/vg=
+github.com/spotinst/spotinst-sdk-go v1.393.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/ocean_aws_launch_configuration/consts.go
+++ b/spotinst/ocean_aws_launch_configuration/consts.go
@@ -56,3 +56,10 @@ const (
 	InstanceStorePolicy     commons.FieldName = "instance_store_policy"
 	InstanceStorePolicyType commons.FieldName = "instance_store_policy_type"
 )
+
+const (
+	StartupTaints       commons.FieldName = "startup_taints"
+	StartupTaintsKey    commons.FieldName = "key"
+	StartupTaintsValue  commons.FieldName = "value"
+	StartupTaintsEffect commons.FieldName = "effect"
+)

--- a/spotinst/ocean_aws_launch_spec/consts.go
+++ b/spotinst/ocean_aws_launch_spec/consts.go
@@ -165,3 +165,10 @@ const (
 	InstanceStorePolicy     commons.FieldName = "instance_store_policy"
 	InstanceStorePolicyType commons.FieldName = "instance_store_policy_type"
 )
+
+const (
+	StartupTaints       commons.FieldName = "startup_taints"
+	StartupTaintsKey    commons.FieldName = "key"
+	StartupTaintsValue  commons.FieldName = "value"
+	StartupTaintsEffect commons.FieldName = "effect"
+)

--- a/spotinst/resource_spotinst_ocean_aws_launch_spec_test.go
+++ b/spotinst/resource_spotinst_ocean_aws_launch_spec_test.go
@@ -189,8 +189,8 @@ func TestAccSpotinstOceanAWSLaunchSpec_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
 					resource.TestCheckResourceAttr(resourceName, "restrict_scale_down", "true"),
 					resource.TestCheckResourceAttr(resourceName, "reserved_enis", "1"),
-					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.key", "startuptaint key"),
-					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.value", "startuptaint value"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.key", "startuptaint-key"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.value", "startuptaint-value"),
 					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.effect", "NoSchedule"),
 				),
 			},
@@ -234,8 +234,8 @@ func TestAccSpotinstOceanAWSLaunchSpec_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "false"),
 					resource.TestCheckResourceAttr(resourceName, "restrict_scale_down", "false"),
 					resource.TestCheckResourceAttr(resourceName, "reserved_enis", "2"),
-					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.key", "startuptaint key updated"),
-					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.value", "startuptaint value updated"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.key", "startuptaint-key-updated"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.value", "startuptaint-value-updated"),
 					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.effect", "NoExecute"),
 				),
 			},
@@ -273,8 +273,8 @@ resource "` + string(commons.OceanAWSLaunchSpecResourceName) + `" "%v" {
   }
 
   startup_taints {
-	key = "startuptaint key"
-	value = "startuptaint value"
+	key = "startuptaint-key"
+	value = "startuptaint-value"
 	effect = "NoSchedule"
   }
 
@@ -313,8 +313,8 @@ resource "` + string(commons.OceanAWSLaunchSpecResourceName) + `" "%v" {
   }
 
   startup_taints {
-	key = "startuptaint key updated"
-	value = "startuptaint value updated"
+	key = "startuptaint-key-updated"
+	value = "startuptaint-value-updated"
 	effect = "NoExecute"
   }
 

--- a/spotinst/resource_spotinst_ocean_aws_launch_spec_test.go
+++ b/spotinst/resource_spotinst_ocean_aws_launch_spec_test.go
@@ -189,6 +189,9 @@ func TestAccSpotinstOceanAWSLaunchSpec_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
 					resource.TestCheckResourceAttr(resourceName, "restrict_scale_down", "true"),
 					resource.TestCheckResourceAttr(resourceName, "reserved_enis", "1"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.key", "startuptaint key"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.value", "startuptaint value"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.effect", "NoSchedule"),
 				),
 			},
 			{
@@ -231,6 +234,9 @@ func TestAccSpotinstOceanAWSLaunchSpec_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "false"),
 					resource.TestCheckResourceAttr(resourceName, "restrict_scale_down", "false"),
 					resource.TestCheckResourceAttr(resourceName, "reserved_enis", "2"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.key", "startuptaint key updated"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.value", "startuptaint value updated"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.effect", "NoExecute"),
 				),
 			},
 		},
@@ -266,6 +272,12 @@ resource "` + string(commons.OceanAWSLaunchSpecResourceName) + `" "%v" {
     effect = "NoSchedule"
   }
 
+  startup_taints {
+	key = "startuptaint key"
+	value = "startuptaint value"
+	effect = "NoSchedule"
+  }
+
  %v
 }
 `
@@ -298,6 +310,12 @@ resource "` + string(commons.OceanAWSLaunchSpecResourceName) + `" "%v" {
     key = "taint key updated"
     value = "taint value updated"
     effect = "NoExecute"
+  }
+
+  startup_taints {
+	key = "startuptaint key updated"
+	value = "startuptaint value updated"
+	effect = "NoExecute"
   }
 
 %v

--- a/spotinst/resource_spotinst_ocean_aws_test.go
+++ b/spotinst/resource_spotinst_ocean_aws_test.go
@@ -409,8 +409,8 @@ func TestAccSpotinstOceanAWS_LaunchConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_metadata_options.0.http_tokens", "required"),
 					resource.TestCheckResourceAttr(resourceName, "resource_tag_specification.0.should_tag_volumes", "true"),
 					resource.TestCheckResourceAttr(resourceName, "reserved_enis", "1"),
-					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.key", "startuptaint key"),
-					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.value", "startuptaint value"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.key", "startuptaint-key"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.value", "startuptaint-value"),
 					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.effect", "NoSchedule"),
 				),
 			},
@@ -450,8 +450,8 @@ func TestAccSpotinstOceanAWS_LaunchConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_metadata_options.0.http_tokens", "optional"),
 					resource.TestCheckResourceAttr(resourceName, "resource_tag_specification.0.should_tag_volumes", "false"),
 					resource.TestCheckResourceAttr(resourceName, "reserved_enis", "2"),
-					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.key", "startuptaint key updated"),
-					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.value", "startuptaint value updated"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.key", "startuptaint-key-updated"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.value", "startuptaint-value-updated"),
 					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.effect", "NoExecute"),
 				),
 			},
@@ -513,8 +513,8 @@ const testLaunchConfigAWSConfig_Create = `
   }
 
   startup_taints {
-	key = "startuptaint key"
-	value = "startuptaint value"
+	key = "startuptaint-key"
+	value = "startuptaint-value"
 	effect = "NoSchedule"
   }
   
@@ -559,8 +559,8 @@ const testLaunchConfigAWSConfig_Update = `
   }
 
   startup_taints {
-	key = "startuptaint key updated"
-	value = "startuptaint value updated"
+	key = "startuptaint-key-updated"
+	value = "startuptaint-value-updated"
 	effect = "NoExecute"
   }
 

--- a/spotinst/resource_spotinst_ocean_aws_test.go
+++ b/spotinst/resource_spotinst_ocean_aws_test.go
@@ -409,6 +409,9 @@ func TestAccSpotinstOceanAWS_LaunchConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_metadata_options.0.http_tokens", "required"),
 					resource.TestCheckResourceAttr(resourceName, "resource_tag_specification.0.should_tag_volumes", "true"),
 					resource.TestCheckResourceAttr(resourceName, "reserved_enis", "1"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.key", "startuptaint key"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.value", "startuptaint value"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.effect", "NoSchedule"),
 				),
 			},
 			{
@@ -447,6 +450,9 @@ func TestAccSpotinstOceanAWS_LaunchConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_metadata_options.0.http_tokens", "optional"),
 					resource.TestCheckResourceAttr(resourceName, "resource_tag_specification.0.should_tag_volumes", "false"),
 					resource.TestCheckResourceAttr(resourceName, "reserved_enis", "2"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.key", "startuptaint key updated"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.value", "startuptaint value updated"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.0.effect", "NoExecute"),
 				),
 			},
 			{
@@ -464,6 +470,7 @@ func TestAccSpotinstOceanAWS_LaunchConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.0", "sg-a22000e8"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "startup_taints.#", "0"),
 				),
 			},
 		},
@@ -504,6 +511,12 @@ const testLaunchConfigAWSConfig_Create = `
     key   = "creator"
     value = "terraform-automation"
   }
+
+  startup_taints {
+	key = "startuptaint key"
+	value = "startuptaint value"
+	effect = "NoSchedule"
+  }
   
   resource_tag_specification {
     should_tag_volumes = true
@@ -543,6 +556,12 @@ const testLaunchConfigAWSConfig_Update = `
   tags {
     key   = "fakeKeyUpdated"
     value = "fakeValueUpdated"
+  }
+
+  startup_taints {
+	key = "startuptaint key updated"
+	value = "startuptaint value updated"
+	effect = "NoExecute"
   }
 
   resource_tag_specification {


### PR DESCRIPTION
added support for `startup_taints` object

https://spotinst.atlassian.net/browse/SI-340

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
