### PR TITLE
fix(statefulnode/azure): removed `should_persist_vm` field from statefulnode configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+##1.220.1 (May 27, 2025)
+BUG FIX:
+* resource/spotinst_stateful_node_azure: Removed `should_persist_vm` field from statefulnode configuration.
+
 ## 1.220.0 (May 16, 2025)
 ENHANCEMENTS:
 * resource/spotinst_credentials_azure: Added `expiration_date` field to support expiry date for Azure App Secret while onboarding Azure Account to Spot.

--- a/spotinst/azure_v3/stateful_node_azure_persistence/fields_spotinst_stateful_node_azure_persistence.go
+++ b/spotinst/azure_v3/stateful_node_azure_persistence/fields_spotinst_stateful_node_azure_persistence.go
@@ -252,6 +252,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Computed: true,
+			Default:  nil,
 		},
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			snWrapper := resourceObject.(*commons.StatefulNodeAzureV3Wrapper)
@@ -268,8 +269,10 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			snWrapper := resourceObject.(*commons.StatefulNodeAzureV3Wrapper)
 			statefulNode := snWrapper.GetStatefulNode()
-			if v, ok := resourceData.Get(string(ShouldPersistVM)).(bool); ok {
-				statefulNode.Persistence.SetShouldPersistVM(spotinst.Bool(v))
+			if v, ok := resourceData.GetOk(string(ShouldPersistVM)); ok && v.(bool) {
+				statefulNode.Persistence.SetShouldPersistVM(spotinst.Bool(v.(bool)))
+			} else {
+				statefulNode.Persistence.SetShouldPersistVM(nil)
 			}
 			return nil
 		},

--- a/spotinst/resource_spotinst_elastigroup_aws_suspend_processes_test.go
+++ b/spotinst/resource_spotinst_elastigroup_aws_suspend_processes_test.go
@@ -115,7 +115,7 @@ func createSuspendProcessesTerraform(ccm *SuspendProcessesMetadata, formatToUse 
 
 // region SuspendProcesses: Baseline
 func TestAccSpotinstSuspendProcessesElastigroupAWS_Baseline(t *testing.T) {
-	groupId := "sig-05d0a009"
+	groupId := "sig-74267bfd"
 	resourceName := createSuspendProcessesResourceName(groupId)
 
 	var spWrapper commons.SuspendProcessesWrapper
@@ -134,7 +134,7 @@ func TestAccSpotinstSuspendProcessesElastigroupAWS_Baseline(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSuspendProcessesExists(spWrapper.SuspendProcesses, resourceName),
 					testSuspendProcessesAttributes(&spWrapper, groupId),
-					resource.TestCheckResourceAttr(resourceName, "group_id", "sig-93207c25"),
+					resource.TestCheckResourceAttr(resourceName, "group_id", "sig-74267bfd"),
 					resource.TestCheckResourceAttr(resourceName, "suspension.#", "4"),
 					resource.TestCheckResourceAttr(resourceName, "suspension.0.name", "SCHEDULING"),
 					resource.TestCheckResourceAttr(resourceName, "suspension.1.name", "PREVENTIVE_REPLACEMENT"),
@@ -150,7 +150,7 @@ func TestAccSpotinstSuspendProcessesElastigroupAWS_Baseline(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSuspendProcessesExists(spWrapper.SuspendProcesses, resourceName),
 					testSuspendProcessesAttributes(&spWrapper, groupId),
-					resource.TestCheckResourceAttr(resourceName, "group_id", "sig-93207c25"),
+					resource.TestCheckResourceAttr(resourceName, "group_id", "sig-74267bfd"),
 					resource.TestCheckResourceAttr(resourceName, "suspension.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "suspension.0.name", "OUT_OF_STRATEGY"),
 					resource.TestCheckResourceAttr(resourceName, "suspension.1.name", "REVERT_PREFERRED"),
@@ -165,7 +165,7 @@ const testBaselineSuspendProcessesConfig_Create = `
 resource "` + string(commons.SuspendProcessesResourceName) + `" "%v" {
   provider = "%v"
 
-	group_id = "sig-93207c25"
+	group_id = "sig-74267bfd"
 	suspension  {
     	name = "SCHEDULING"
   	}
@@ -186,7 +186,7 @@ const testBaselineSuspendProcessesConfig_Update = `
 resource "` + string(commons.SuspendProcessesResourceName) + `" "%v" {
 	provider = "%v"
 
- 	group_id = "sig-93207c25"
+ 	group_id = "sig-74267bfd"
   	suspension  {
     	name = "OUT_OF_STRATEGY"
 	  }
@@ -204,7 +204,7 @@ resource "` + string(commons.SuspendProcessesResourceName) + `" "%v" {
 
 // region SuspendProcesses: RemoveSuspension
 func TestAccSpotinstSuspendProcessesElastigroupAWS_RemoveSuspension(t *testing.T) {
-	groupId := "sig-05d0a009"
+	groupId := "sig-74267bfd"
 	resourceName := createSuspendProcessesResourceName(groupId)
 
 	var spWrapper commons.SuspendProcessesWrapper
@@ -223,7 +223,7 @@ func TestAccSpotinstSuspendProcessesElastigroupAWS_RemoveSuspension(t *testing.T
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSuspendProcessesExists(spWrapper.SuspendProcesses, resourceName),
 					testSuspendProcessesAttributes(&spWrapper, groupId),
-					resource.TestCheckResourceAttr(resourceName, "group_id", "sig-93207c25"),
+					resource.TestCheckResourceAttr(resourceName, "group_id", "sig-74267bfd"),
 					resource.TestCheckResourceAttr(resourceName, "suspension.#", "4"),
 					resource.TestCheckResourceAttr(resourceName, "suspension.0.name", "SCHEDULING"),
 					resource.TestCheckResourceAttr(resourceName, "suspension.1.name", "PREVENTIVE_REPLACEMENT"),
@@ -239,7 +239,7 @@ func TestAccSpotinstSuspendProcessesElastigroupAWS_RemoveSuspension(t *testing.T
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSuspendProcessesExists(spWrapper.SuspendProcesses, resourceName),
 					testSuspendProcessesAttributes(&spWrapper, groupId),
-					resource.TestCheckResourceAttr(resourceName, "group_id", "sig-93207c25"),
+					resource.TestCheckResourceAttr(resourceName, "group_id", "sig-74267bfd"),
 					resource.TestCheckResourceAttr(resourceName, "suspension.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "suspension.0.name", "OUT_OF_STRATEGY"),
 					resource.TestCheckResourceAttr(resourceName, "suspension.1.name", "REVERT_PREFERRED"),
@@ -254,7 +254,7 @@ const testRemoveSuspensionSuspendProcessesConfig_Create = `
 resource "` + string(commons.SuspendProcessesResourceName) + `" "%v" {
   provider = "%v"
 
-	group_id = "sig-93207c25"
+	group_id = "sig-74267bfd"
 	suspension  {
     	name = "OUT_OF_STRATEGY"
   	}
@@ -275,7 +275,7 @@ const testRemoveSuspensionSuspendProcessesConfig_Update = `
 resource "` + string(commons.SuspendProcessesResourceName) + `" "%v" {
 	provider = "%v"
 
- 	group_id = "sig-93207c25"
+ 	group_id = "sig-74267bfd"
   	suspension  {
     	name = "SCHEDULING"
   	}

--- a/spotinst/resource_spotinst_elastigroup_health_check_test.go
+++ b/spotinst/resource_spotinst_elastigroup_health_check_test.go
@@ -172,7 +172,7 @@ func TestAccSpotinstHealthCheckBaseline(t *testing.T) {
 const testBaselineHealthCheckConfig_Create = `
 resource "` + string(commons.HealthCheckResourceName) + `" "%v" {
   provider = "%v"
-    resource_id = "sig-93207c25"
+    resource_id = "sig-74267bfd"
     name = "test-acc-health_check_terraform_test"
     proxy_address = "http://proxy.com"
     proxy_port = "6"
@@ -192,7 +192,7 @@ resource "` + string(commons.HealthCheckResourceName) + `" "%v" {
 const testBaselineHealthCheckConfig_Update = `
 resource "` + string(commons.HealthCheckResourceName) + `" "%v" {
   provider = "%v"
-  resource_id = "sig-93207c25"
+  resource_id = "sig-74267bfd"
   name = "test-acc-health_check_terraform_test"
   proxy_address = "http://proxy.com"
   proxy_port = "7"

--- a/spotinst/resource_spotinst_ocean_aks_np_test.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_test.go
@@ -223,7 +223,7 @@ func TestAccSpotinstOceanAKSNP_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "os_disk_type", "Managed"),
 					resource.TestCheckResourceAttr(resourceName, "os_type", "Linux"),
 					resource.TestCheckResourceAttr(resourceName, "os_sku", "Ubuntu"),
-					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.29"),
+					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.30"),
 					resource.TestCheckResourceAttr(resourceName, "spot_percentage", "50"),
 					resource.TestCheckResourceAttr(resourceName, "fallback_to_ondemand", "false"),
 					//resource.TestCheckResourceAttr(resourceName, "vnet_subnet_ids.#", "1"),
@@ -250,7 +250,7 @@ func TestAccSpotinstOceanAKSNP_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_pods_per_node", "50"),
 					resource.TestCheckResourceAttr(resourceName, "enable_node_public_ip", "true"),
 					resource.TestCheckResourceAttr(resourceName, "os_disk_size_gb", "64"),
-					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.29"),
+					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.30"),
 					resource.TestCheckResourceAttr(resourceName, "spot_percentage", "100"),
 					resource.TestCheckResourceAttr(resourceName, "fallback_to_ondemand", "true"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.#", "3"),
@@ -295,7 +295,7 @@ resource "` + string(commons.OceanAKSNPResourceName) + `" "%v" {
   os_disk_type          = "Managed"
   os_type               = "Linux"
   os_sku                = "Ubuntu"
-  kubernetes_version    = "1.29"
+  kubernetes_version    = "1.30"
   //vnet_subnet_ids       = ["/subscriptions/a9e813ad-f18b-4ad2-9dbc-5c6df28e9cb8/resourceGroups/AutomationResourceGroup/providers/Microsoft.Network/virtualNetworks/Automation-VirtualNetwork/subnets/default"]
   // ----------------------------------------------------------------------
   linux_os_config {
@@ -353,7 +353,7 @@ resource "` + string(commons.OceanAKSNPResourceName) + `" "%v" {
   os_disk_type          = "Managed"
   os_type               = "Linux"
   os_sku                = "Ubuntu"
-  kubernetes_version    = "1.29"
+  kubernetes_version    = "1.30"
   //vnet_subnet_ids       = ["/subscriptions/a9e813ad-f18b-4ad2-9dbc-5c6df28e9cb8/resourceGroups/AutomationResourceGroup/providers/Microsoft.Network/virtualNetworks/Automation-VirtualNetwork/subnets/default"]
   // ----------------------------------------------------------------------
   linux_os_config {

--- a/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group_test.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group_test.go
@@ -136,7 +136,7 @@ func TestAccSpotinstOceanAKSNPVirtualNodeGroup_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "os_disk_type", "Managed"),
 					resource.TestCheckResourceAttr(resourceName, "os_type", "Linux"),
 					resource.TestCheckResourceAttr(resourceName, "os_sku", "Ubuntu"),
-					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.29"),
+					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.30"),
 					resource.TestCheckResourceAttr(resourceName, "spot_percentage", "50"),
 					resource.TestCheckResourceAttr(resourceName, "fallback_to_ondemand", "false"),
 					//resource.TestCheckResourceAttr(resourceName, "vnet_subnet_ids.#", "1"),
@@ -159,7 +159,7 @@ func TestAccSpotinstOceanAKSNPVirtualNodeGroup_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_pods_per_node", "50"),
 					resource.TestCheckResourceAttr(resourceName, "enable_node_public_ip", "false"),
 					resource.TestCheckResourceAttr(resourceName, "os_disk_size_gb", "64"),
-					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.29"),
+					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.30"),
 					resource.TestCheckResourceAttr(resourceName, "spot_percentage", "100"),
 					resource.TestCheckResourceAttr(resourceName, "fallback_to_ondemand", "true"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.#", "3"),
@@ -201,7 +201,7 @@ resource "` + string(commons.OceanAKSNPVirtualNodeGroupResourceName) + `" "%v" {
   os_disk_type          = "Managed"
   os_type               = "Linux"
   os_sku                = "Ubuntu"
-  kubernetes_version    = "1.29"
+  kubernetes_version    = "1.30"
   //vnet_subnet_ids       = ["/subscriptions/a9e813ad-f18b-4ad2-9dbc-5c6df28e9cb8/resourceGroups/AutomationResourceGroup/providers/Microsoft.Network/virtualNetworks/Automation-VirtualNetwork/subnets/default"]
   linux_os_config {
    sysctls {
@@ -246,7 +246,7 @@ resource "` + string(commons.OceanAKSNPVirtualNodeGroupResourceName) + `" "%v" {
   os_disk_type          = "Managed"
   os_type               = "Linux"
   os_sku                = "Ubuntu"
-  kubernetes_version    = "1.29"
+  kubernetes_version    = "1.30"
   //vnet_subnet_ids       = ["/subscriptions/123456-1234-1234-1234-123456789/resourceGroups/ExampleResourceGroup/providers/Microsoft.Network/virtualNetworks/ExampleVirtualNetwork/subnets/default"]
   linux_os_config {
    sysctls {


### PR DESCRIPTION
removed `should_persist_vm` field from statefulnode configuration

https://spotinst.atlassian.net/browse/SI-351


# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
