### PR TITLE
fix(statefulnode/azure): Removed `should_persist_vm` field from `persistence` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+##1.220.2 (May 27, 2025)
+BUG FIX:
+* resource/spotinst_stateful_node_azure: Removed `should_persist_vm` field from `persistence` object.
+
 ##1.220.1 (May 27, 2025)
 BUG FIX:
 * resource/spotinst_stateful_node_azure: Removed `should_persist_vm` field from statefulnode configuration.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.394.0
+	github.com/spotinst/spotinst-sdk-go v1.394.1
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0
 github.com/skeema/knownhosts v1.3.0/go.mod h1:sPINvnADmT/qYH1kfv+ePMmOBTH6Tbl7b5LvTDjFK7M=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.394.0 h1:ofN0joWLXpIJMpOCnxze9y91eKeQiXKDJh2JYTFS0KI=
-github.com/spotinst/spotinst-sdk-go v1.394.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.394.1 h1:d7oLTplCYj4WrYAok3FFCnfSx14QYs0/F9Y+QBIFSUg=
+github.com/spotinst/spotinst-sdk-go v1.394.1/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/azure_v3/stateful_node_azure_persistence/consts.go
+++ b/spotinst/azure_v3/stateful_node_azure_persistence/consts.go
@@ -8,5 +8,4 @@ const (
 	ShouldPersistDataDisks   commons.FieldName = "should_persist_data_disks"
 	DataDisksPersistenceMode commons.FieldName = "data_disks_persistence_mode"
 	ShouldPersistNetwork     commons.FieldName = "should_persist_network"
-	ShouldPersistVM          commons.FieldName = "should_persist_vm"
 )

--- a/spotinst/azure_v3/stateful_node_azure_persistence/fields_spotinst_stateful_node_azure_persistence.go
+++ b/spotinst/azure_v3/stateful_node_azure_persistence/fields_spotinst_stateful_node_azure_persistence.go
@@ -244,47 +244,4 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		},
 		nil,
 	)
-
-	fieldsMap[ShouldPersistVM] = commons.NewGenericField(
-		commons.StatefulNodeAzurePersistence,
-		ShouldPersistVM,
-		&schema.Schema{
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: true,
-			Default:  nil,
-		},
-		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
-			snWrapper := resourceObject.(*commons.StatefulNodeAzureV3Wrapper)
-			statefulNode := snWrapper.GetStatefulNode()
-			var value *bool = nil
-			if statefulNode.Persistence != nil && statefulNode.Persistence.ShouldPersistVM != nil {
-				value = statefulNode.Persistence.ShouldPersistVM
-			}
-			if err := resourceData.Set(string(ShouldPersistVM), spotinst.BoolValue(value)); err != nil {
-				return fmt.Errorf(string(commons.FailureFieldReadPattern), string(ShouldPersistVM), err)
-			}
-			return nil
-		},
-		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
-			snWrapper := resourceObject.(*commons.StatefulNodeAzureV3Wrapper)
-			statefulNode := snWrapper.GetStatefulNode()
-			if v, ok := resourceData.GetOk(string(ShouldPersistVM)); ok && v.(bool) {
-				statefulNode.Persistence.SetShouldPersistVM(spotinst.Bool(v.(bool)))
-			} else {
-				statefulNode.Persistence.SetShouldPersistVM(nil)
-			}
-			return nil
-		},
-		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
-			snWrapper := resourceObject.(*commons.StatefulNodeAzureV3Wrapper)
-			statefulNode := snWrapper.GetStatefulNode()
-			if v, ok := resourceData.Get(string(ShouldPersistVM)).(bool); ok {
-				statefulNode.Persistence.SetShouldPersistVM(spotinst.Bool(v))
-			}
-			return nil
-		},
-		nil,
-	)
-
 }

--- a/spotinst/resource_spotinst_stateful_node_azure_test.go
+++ b/spotinst/resource_spotinst_stateful_node_azure_test.go
@@ -436,7 +436,6 @@ func TestAccSpotinstStatefulNodeAzureV3_Persistence(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "should_persist_data_disks", "false"),
 					resource.TestCheckResourceAttr(resourceName, "data_disks_persistence_mode", "reattach"),
 					resource.TestCheckResourceAttr(resourceName, "should_persist_network", "true"),
-					resource.TestCheckResourceAttr(resourceName, "should_persist_vm", "false"),
 				),
 			},
 			{
@@ -464,7 +463,6 @@ os_disk_persistence_mode = "reattach"
 should_persist_data_disks = false
 data_disks_persistence_mode = "reattach"
 should_persist_network = true
-should_persist_vm = false
 `
 
 const testPersistenceStatefulNodeAzureV3Config_Update = `


### PR DESCRIPTION
Removed `should_persist_vm` field from persistence object

https://spotinst.atlassian.net/browse/SI-351

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
