### PR TITLE
fix(stateful_node/azure): fixed `security` object to accept null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+##1.220.3 (Jun 23, 2025)
+BUG FIX:
+* resource/spotinst_stateful_node_azure: Fixed `security` object accept null and ignore the object when not configured.
+
 ##1.220.2 (May 27, 2025)
 BUG FIX:
 * resource/spotinst_stateful_node_azure: Removed `should_persist_vm` field from `persistence` object.

--- a/spotinst/azure_v3/stateful_node_azure_launch_spec/fields_spotinst_stateful_node_azure_launch_spec.go
+++ b/spotinst/azure_v3/stateful_node_azure_launch_spec/fields_spotinst_stateful_node_azure_launch_spec.go
@@ -695,6 +695,7 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 					string(SecureBootEnabled): {
 						Type:     schema.TypeBool,
 						Optional: true,
+						Default:  nil,
 					},
 					string(SecurityType): {
 						Type:     schema.TypeString,
@@ -703,14 +704,17 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 					string(VTpmEnabled): {
 						Type:     schema.TypeBool,
 						Optional: true,
+						Default:  nil,
 					},
 					string(EncryptionAtHost): {
 						Type:     schema.TypeBool,
 						Optional: true,
+						Default:  nil,
 					},
 					string(ConfidentialOsDiskEncryption): {
 						Type:     schema.TypeBool,
 						Optional: true,
+						Default:  nil,
 					},
 				},
 			},
@@ -732,24 +736,19 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			stWrapper := resourceObject.(*commons.StatefulNodeAzureV3Wrapper)
 			st := stWrapper.GetStatefulNode()
-			var value *azure.Security = nil
-
 			if v, ok := resourceData.GetOk(string(Security)); ok {
 				if security, err := expandSecurity(v); err != nil {
 					return err
-				} else {
-					value = security
+				} else if security != nil {
+					st.Compute.LaunchSpecification.SetSecurity(security)
 				}
 			}
-			st.Compute.LaunchSpecification.SetSecurity(value)
-
 			return nil
 		},
 		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
 			stWrapper := resourceObject.(*commons.StatefulNodeAzureV3Wrapper)
 			st := stWrapper.GetStatefulNode()
 			var value *azure.Security = nil
-
 			if v, ok := resourceData.GetOk(string(Security)); ok {
 				if security, err := expandSecurity(v); err != nil {
 					return err
@@ -1002,26 +1001,45 @@ func expandSecurity(data interface{}) (*azure.Security, error) {
 		if list[0] != nil {
 			m := list[0].(map[string]interface{})
 
-			if v, ok := m[string(SecureBootEnabled)].(bool); ok {
-				security.SetSecureBootEnabled(spotinst.Bool(v))
+			if v, exists := m[string(SecureBootEnabled)]; exists && v != nil {
+				if b, ok := v.(bool); ok {
+					security.SetSecureBootEnabled(spotinst.Bool(b))
+				}
+			}
+
+			if v, exists := m[string(EncryptionAtHost)]; exists && v != nil {
+				if b, ok := v.(bool); ok {
+					security.SetEncryptionAtHost(spotinst.Bool(b))
+				}
+			}
+
+			if v, exists := m[string(ConfidentialOsDiskEncryption)]; exists && v != nil {
+				if b, ok := v.(bool); ok {
+					security.SetConfidentialOsDiskEncryption(spotinst.Bool(b))
+				}
 			}
 
 			if v, ok := m[string(SecurityType)].(string); ok && v != "" {
 				security.SetSecurityType(spotinst.String(v))
 			}
 
-			if v, ok := m[string(VTpmEnabled)].(bool); ok {
-				security.SetVTpmEnabled(spotinst.Bool(v))
+			if v, exists := m[string(VTpmEnabled)]; exists && v != nil {
+				if b, ok := v.(bool); ok {
+					security.SetVTpmEnabled(spotinst.Bool(b))
+				}
 			}
 
-			if v, ok := m[string(EncryptionAtHost)].(bool); ok {
-				security.SetEncryptionAtHost(spotinst.Bool(v))
+			if v, exists := m[string(EncryptionAtHost)]; exists && v != nil {
+				if b, ok := v.(bool); ok {
+					security.SetEncryptionAtHost(spotinst.Bool(b))
+				}
 			}
 
-			if v, ok := m[string(ConfidentialOsDiskEncryption)].(bool); ok {
-				security.SetConfidentialOsDiskEncryption(spotinst.Bool(v))
+			if v, exists := m[string(ConfidentialOsDiskEncryption)]; exists && v != nil {
+				if b, ok := v.(bool); ok {
+					security.SetConfidentialOsDiskEncryption(spotinst.Bool(b))
+				}
 			}
-
 		}
 
 		return security, nil


### PR DESCRIPTION
fixed `security` object to accept null

https://spotinst.atlassian.net/browse/SI-360
# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
