### PR TITLE
fix(stateful-node/azure): Fixed `confidential_os_disk_encryption` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+##1.220.4 (Jun 26, 2025)
+BUG FIX:
+* resource/spotinst_stateful_node_azure: Fixed `confidential_os_disk_encryption` field to accept null instead of defaulting to false in `security` object.
+
 ##1.220.3 (Jun 23, 2025)
 BUG FIX:
 * resource/spotinst_stateful_node_azure: Fixed `security` object accept null and ignore the object when not configured.


### PR DESCRIPTION
Fixed `confidential_os_disk_encryption` field to accept null instead of defaulting to false in `security` object
https://spotinst.atlassian.net/browse/SI-362
# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
