### PR TITLE
fix: Fixing AWS autoscale_headroom drift caused by default values

### DIFF
--- a/spotinst/ocean_aws_auto_scaling/fields_spotinst_ocean_aws_auto_scaling.go
+++ b/spotinst/ocean_aws_auto_scaling/fields_spotinst_ocean_aws_auto_scaling.go
@@ -68,24 +68,20 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 								string(CPUPerUnit): {
 									Type:     schema.TypeInt,
 									Optional: true,
-									Default:  -1,
 								},
 
 								string(GPUPerUnit): {
 									Type:     schema.TypeInt,
 									Optional: true,
-									Default:  -1,
 								},
 								string(MemoryPerUnit): {
 									Type:     schema.TypeInt,
 									Optional: true,
-									Default:  -1,
 								},
 
 								string(NumOfUnits): {
 									Type:     schema.TypeInt,
 									Optional: true,
-									Default:  -1,
 								},
 							},
 						},


### PR DESCRIPTION
The autoscale_headroom parameters are always causing drift compared to the changes applied to Ocean. The provider is setting it -1 by default, as you can see [here](https://github.com/spotinst/terraform-provider-spotinst/blob/b3e313382e4df1d1f36157b66dfcef620120cf57/spotinst/ocean_aws_auto_scaling/fields_spotinst_ocean_aws_auto_scaling.go#L62)

```
autoscale_headroom {
  cpu_per_unit    = var.cpu_per_unit
  gpu_per_unit    = var.gpu_per_unit
  memory_per_unit = var.memory_per_unit
  num_of_units    = var.num_of_unit
}
```

<img width="421" height="264" alt="Screenshot 2025-07-22 at 11 00 23 AM" src="https://github.com/user-attachments/assets/043cdb12-fcc3-48a1-9374-7c7d41605ba8" />

> [!NOTE]
> I also opened a [PR](https://github.com/spotinst/terraform-spotinst-ocean-aws-k8s/pull/57) in the [terraform-spotinst-ocean-aws-k8s](https://github.com/spotinst/terraform-spotinst-ocean-aws-k8s) setting the default values as 0, so I believe one of them can be accepted.