### PR TITLE
feat(ocean/aws): added `primary_ipv6` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.225.0 (Aug 11, 2025)
+ENHANCEMENTS:
+* resource/spotinst_ocean_aws: Added `primary_ipv6` field to Enable assignment of a primary IPv6 address to the cluster.
+
 ## 1.224.1 (Jul 23, 2025)
 BUG FIXES:
 * resource/spotinst_ocean_aws: Fixed `autoscale_headroom` object to remove default of negative value to ignore the drift shown during plan.

--- a/docs/resources/ocean_aws.md
+++ b/docs/resources/ocean_aws.md
@@ -85,6 +85,7 @@ resource "spotinst_ocean_aws" "example" {
   ebs_optimized                                      = true
   associate_public_ip_address                        = true
   associate_ipv6_address                             = true
+  primary_ipv6                                       = true
   use_as_template_only                               = true
   health_check_unhealthy_duration_before_replacement = 60
   reserved_enis                                      = 1
@@ -209,6 +210,7 @@ The following arguments are supported:
 * `iam_instance_profile` - (Optional) The instance profile iam role.
 * `associate_public_ip_address` - (Optional, Default: `false`) Configure public IP address allocation.
 * `associate_ipv6_address` - (Optional, Default: `false`) Configure IPv6 address allocation.
+* `primary_ipv6` - (Optional) Enables assignment of a primary IPv6 address to the cluster. This feature is only available when `associate_ipv6_address` is explicitly set to true. Additionally, the cluster must have been initially created as an EKS cluster in IPv6 mode.
 * `root_volume_size` - (Optional) The size (in Gb) to allocate for the root volume. Minimum `20`.
 * `monitoring` - (Optional) Enable detailed monitoring for cluster. Flag will enable Cloud Watch detailed monitoring (one minute increments). Note: there are additional hourly costs for this service based on the region used.
 * `ebs_optimized` - (Optional) Enable EBS optimized for cluster. Flag will enable optimized capacity for high bandwidth connectivity to the EB service for non EBS optimized instance types. For instances that are EBS optimized this flag will be ignored.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.398.1
+	github.com/spotinst/spotinst-sdk-go v1.399.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0
 github.com/skeema/knownhosts v1.3.0/go.mod h1:sPINvnADmT/qYH1kfv+ePMmOBTH6Tbl7b5LvTDjFK7M=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.398.1 h1:ydDbUlMllwHQJ4VJlxgYYW7pNf6A5rGtg9ehCVF74tc=
-github.com/spotinst/spotinst-sdk-go v1.398.1/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.399.0 h1:EK3Y+3SUBsSSshCVwPvAn1TXJRq2NOzrEhbtmMsQS3g=
+github.com/spotinst/spotinst-sdk-go v1.399.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/ocean_aws_launch_configuration/consts.go
+++ b/spotinst/ocean_aws_launch_configuration/consts.go
@@ -22,6 +22,7 @@ const (
 	ShouldTagVolumes                              commons.FieldName = "should_tag_volumes"
 	HealthCheckUnhealthyDurationBeforeReplacement commons.FieldName = "health_check_unhealthy_duration_before_replacement"
 	ReservedENIs                                  commons.FieldName = "reserved_enis"
+	PrimaryIPv6                                   commons.FieldName = "primary_ipv6"
 )
 
 const (

--- a/spotinst/ocean_aws_launch_configuration/fields_spotinst_ocean_aws_launch_configuration.go
+++ b/spotinst/ocean_aws_launch_configuration/fields_spotinst_ocean_aws_launch_configuration.go
@@ -1112,6 +1112,51 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		},
 		nil,
 	)
+
+	fieldsMap[PrimaryIPv6] = commons.NewGenericField(
+		commons.OceanAWSLaunchConfiguration,
+		PrimaryIPv6,
+		&schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.AWSClusterWrapper)
+			cluster := clusterWrapper.GetCluster()
+
+			var value *bool = nil
+			if cluster.Compute != nil && cluster.Compute.LaunchSpecification != nil &&
+				cluster.Compute.LaunchSpecification.PrimaryIPv6 != nil {
+
+				value = cluster.Compute.LaunchSpecification.PrimaryIPv6
+			}
+
+			if err := resourceData.Set(string(PrimaryIPv6), value); err != nil {
+				return fmt.Errorf(string(commons.FailureFieldReadPattern), string(PrimaryIPv6), err)
+			}
+
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.AWSClusterWrapper)
+			cluster := clusterWrapper.GetCluster()
+
+			if v, ok := resourceData.GetOkExists(string(PrimaryIPv6)); ok {
+				cluster.Compute.LaunchSpecification.SetPrimaryIPv6(spotinst.Bool(v.(bool)))
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.AWSClusterWrapper)
+			cluster := clusterWrapper.GetCluster()
+
+			if v, ok := resourceData.GetOkExists(string(PrimaryIPv6)); ok {
+				cluster.Compute.LaunchSpecification.SetPrimaryIPv6(spotinst.Bool(v.(bool)))
+			}
+			return nil
+		},
+		nil,
+	)
 }
 
 func flattenResourceTagSpecification(resourceTagSpecification *aws.ResourceTagSpecification) []interface{} {

--- a/spotinst/resource_spotinst_ocean_aws_test.go
+++ b/spotinst/resource_spotinst_ocean_aws_test.go
@@ -390,6 +390,7 @@ func TestAccSpotinstOceanAWS_LaunchConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "security_groups.0", "sg-a22000e8"),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "false"),
 					resource.TestCheckResourceAttr(resourceName, "associate_ipv6_address", "false"),
+					resource.TestCheckResourceAttr(resourceName, "primary_ipv6", "false"),
 					//resource.TestCheckResourceAttr(resourceName, "key_name", "my-key.ssh"),
 					resource.TestCheckResourceAttr(resourceName, "user_data", ocean_aws_launch_configuration.Base64StateFunc("echo hello world")),
 					//resource.TestCheckResourceAttr(resourceName, "iam_instance_profile", "iam-profile"),
@@ -430,6 +431,7 @@ func TestAccSpotinstOceanAWS_LaunchConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "security_groups.0", "sg-a22000e8"),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
 					resource.TestCheckResourceAttr(resourceName, "associate_ipv6_address", "true"),
+					resource.TestCheckResourceAttr(resourceName, "primary_ipv6", "true"),
 					//resource.TestCheckResourceAttr(resourceName, "key_name", "my-key-updated.ssh"),
 					resource.TestCheckResourceAttr(resourceName, "user_data", ocean_aws_launch_configuration.Base64StateFunc("echo hello world updated")),
 					//resource.TestCheckResourceAttr(resourceName, "iam_instance_profile", "iam-profile updated"),
@@ -487,6 +489,7 @@ const testLaunchConfigAWSConfig_Create = `
   //iam_instance_profile      						  = "iam-profile"
   associate_public_ip_address 						  = false
   associate_ipv6_address 	  						  = false
+  primary_ipv6										  = false
   root_volume_size            						  = 20
   monitoring                  					  	  = true
   ebs_optimized               						  = true
@@ -534,6 +537,7 @@ const testLaunchConfigAWSConfig_Update = `
   //iam_instance_profile                              = "iam-profile updated"
   associate_public_ip_address                         = true
   associate_ipv6_address 	                          = true
+  primary_ipv6										  = true
   root_volume_size                                    = 24
   monitoring                                          = false
   ebs_optimized                                       = false


### PR DESCRIPTION
added `primary_ipv6` field

https://spotinst.atlassian.net/browse/SI-389

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
