### PR TITLE
fix(elastigroup/aws): Fixed `availability_zones` object to accept multiple subnets of same zone in one block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.225.1 (Aug, 19 2025)
+BUG FIX:
+* resource/spotinst_elastigroup_aws: Fixed `availability_zones` object to accept multiple subnets of same zone in one block.
+
 ## 1.225.0 (Aug 11, 2025)
 ENHANCEMENTS:
 * resource/spotinst_ocean_aws: Added `primary_ipv6` field to Enable assignment of a primary IPv6 address to the cluster.

--- a/spotinst/resource_spotinst_elastigroup_aws_test.go
+++ b/spotinst/resource_spotinst_elastigroup_aws_test.go
@@ -230,7 +230,7 @@ resource "` + string(commons.ElastigroupAWSResourceName) + `" "%v" {
 	name 				= "%v"
 	description 		= "created by Terraform"
 	product 			= "Linux/UNIX"
-	availability_zones = ["us-west-2b", "us-west-2c"]
+	availability_zones = ["us-west-2b:subnet-8ab89cc1", "us-west-2c:subnet-42f1e418"]
 	
 	// --- CAPACITY ------------
 	max_size 		  = 0
@@ -254,7 +254,7 @@ resource "` + string(commons.ElastigroupAWSResourceName) + `" "%v" {
 	name 							= "%v"
 	description  			= "created by Terraform"
 	product 						= "Linux/UNIX"
-	availability_zones = ["us-west-2a"]
+	availability_zones = ["us-west-2a:subnet-4333093a"]
 	
 	// --- CAPACITY ------------
 	max_size 		    = 0


### PR DESCRIPTION
Fixed `availability_zones` object to accept multiple subnets of same zone in one block.

https://spotinst.atlassian.net/browse/SI-385

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
