### PR TITLE
feat(ocean_launch_spec/gke): Added `filters` object to support filtering the instance types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.226.0 (Aug, 29 2025)
+ENHANCEMENTS:
+* resource/spotinst_ocean_gke_launch_spec: Added `filters` object to support filtering the instance types.
+
 ## 1.225.1 (Aug, 19 2025)
 BUG FIX:
 * resource/spotinst_elastigroup_aws: Fixed `availability_zones` object to accept multiple subnets of same zone in one block.

--- a/docs/resources/ocean_gke_launch_spec.md
+++ b/docs/resources/ocean_gke_launch_spec.md
@@ -102,6 +102,15 @@ resource "spotinst_ocean_gke_launch_spec" "example" {
       subnetwork_range_name = "gke-test-native-vpc-pods-123456-vng"
     }
   }
+  
+   filters {
+    exclude_families          =   ["n2"]
+    include_families          =   ["c2", "c3"]
+    min_memory_gib            =   8
+    max_memory_gib            =   16
+    min_vcpu                  =   2
+    max_vcpu                  =   16
+  }
 }
 ```
 ```
@@ -172,6 +181,13 @@ The following arguments are supported:
   * `alias_ip_ranges` - (Optional) use the imported node pool’s associated aliasIpRange to assign secondary IP addresses to the nodes. Cannot be changed after VNG creation.
     * `ip_cidr_range` - (Required) specify the IP address range in CIDR notation that can be used for the alias IP addresses associated with the imported node pool.
     * `subnetwork_range_name` - (Required) specify the IP address range for the subnet secondary IP range.
+* `filters` - (Optional) List of filters. The Instance types that match with all filters compose the Ocean's whitelist parameter. Cannot be configured if cluster's `instance_types` is configured.
+  * `exclude_families` - (Optional) Types belonging to a family from the ExcludeFamilies will not be available for scaling (asterisk wildcard is also supported). For example, C* will exclude instance types from these families: c5, c4, c4a, etc.
+  * `include_families` - (Optional) Types belonging to a family from the IncludeFamilies will be available for scaling (asterisk wildcard is also supported). For example, C* will include instance types from these families: c5, c4, c4a, etc.
+  * `max_memory_gib` - (Optional) Maximum amount of Memory (GiB).
+  * `max_vcpu` - (Optional) Maximum number of vcpus available.
+  * `min_memory_gib` - (Optional) Minimum amount of Memory (GiB).
+  * `min_vcpu` - (Optional) Minimum number of vcpus available.
 
 <a id="update-policy"></a>
 ## Update Policy

--- a/docs/resources/ocean_gke_launch_spec.md
+++ b/docs/resources/ocean_gke_launch_spec.md
@@ -107,7 +107,7 @@ resource "spotinst_ocean_gke_launch_spec" "example" {
     exclude_families          =   ["n2"]
     include_families          =   ["c2", "c3"]
     min_memory_gib            =   8
-    max_memory_gib            =   16
+    max_memory_gib            =   32
     min_vcpu                  =   2
     max_vcpu                  =   16
   }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.399.0
+	github.com/spotinst/spotinst-sdk-go v1.400.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0
 github.com/skeema/knownhosts v1.3.0/go.mod h1:sPINvnADmT/qYH1kfv+ePMmOBTH6Tbl7b5LvTDjFK7M=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.399.0 h1:EK3Y+3SUBsSSshCVwPvAn1TXJRq2NOzrEhbtmMsQS3g=
-github.com/spotinst/spotinst-sdk-go v1.399.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.400.0 h1:joY+CLNs5VlWfbydycGHjizaVHy8FgEIpRL3yGjy97Y=
+github.com/spotinst/spotinst-sdk-go v1.400.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/ocean_gke_launch_spec/consts.go
+++ b/spotinst/ocean_gke_launch_spec/consts.go
@@ -83,3 +83,13 @@ const (
 	CreateOptions commons.FieldName = "create_options"
 	InitialNodes  commons.FieldName = "initial_nodes"
 )
+
+const (
+	Filters         commons.FieldName = "filters"
+	ExcludeFamilies commons.FieldName = "exclude_families"
+	IncludeFamilies commons.FieldName = "include_families"
+	MaxMemoryGiB    commons.FieldName = "max_memory_gib"
+	MaxVcpu         commons.FieldName = "max_vcpu"
+	MinMemoryGiB    commons.FieldName = "min_memory_gib"
+	MinVcpu         commons.FieldName = "min_vcpu"
+)


### PR DESCRIPTION
Added `filters` object to support filtering the instance types

https://spotinst.atlassian.net/browse/SI-398

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
