### PR TITLE
fix(ocean/aws_launch_spec): always send user_data on update when set

### DIFF
--- a/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
+++ b/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
@@ -184,7 +184,20 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 			launchSpec.SetUserData(userData)
 			return nil
 		},
-		nil,
+		// Always include user_data in the PUT body when it is set in config.
+		// Without this, the default HasChange-based gate has been observed to
+		// miss diffs on user_data (the resource-level apply runs and
+		// updatedAt advances, but the live user_data is unchanged on the
+		// backend). Forcing user_data to flow through onUpdate on every apply
+		// makes this class of silent non-persist impossible for this field.
+		// Cost is one extra well-formed field in the PATCH body per apply
+		// when user_data is configured, which is negligible.
+		func(resourceData *schema.ResourceData, meta interface{}) bool {
+			if v, ok := resourceData.Get(string(UserData)).(string); ok && v != "" {
+				return true
+			}
+			return resourceData.HasChange(string(UserData))
+		},
 	)
 
 	fieldsMap[Labels] = commons.NewGenericField(


### PR DESCRIPTION
## Problem

Operators using `spotinst_ocean_aws_launch_spec` with a non-trivial `user_data` (an EC2 cloud-init script in the ~15 KB range) have observed multiple cases where `terraform apply` reports success and the launch spec's `updatedAt` advances on the backend, but the live `user_data` field is still the **pre-apply** bytes.

Verification flow that surfaces it:
1. Edit `user_data` on disk (or change the source file referenced in the resource).
2. `terraform plan` shows the diff.
3. `terraform apply` reports `Apply complete! Resources: 0 added, N changed, 0 destroyed`.
4. `GET /ocean/aws/k8s/launchSpec/{id}` shows `updatedAt` advanced.
5. Decode `userData` from the GET, sha256 it. Compare to sha256 of the on-disk file.
6. They do not match — the live `userData` is still the pre-apply value.
7. New instances launching from this VNG boot with the pre-apply user_data.

This has been observed multiple times across multiple launch spec IDs, in different update windows, with `terraform-provider-spotinst` v1.235 and v1.236.

A direct `PUT /ocean/aws/k8s/launchSpec/{id}` with `{"launchSpec": {"userData": "<base64>"}}` (the same payload shape the provider would send) persists correctly every time. So the backend write path works; something about the provider's update path is dropping `user_data` from the body in some cases. After such an out-of-band PUT, `terraform plan` correctly observes no drift, which suggests the **read** path is fine — the issue is exclusively in the **write** path.

## Root cause hypothesis

`OnUpdate` in `spotinst/commons/common_ocean_aws_launch_spec.go:81-104` iterates fields and calls each field's `onUpdate` callback only when `hasFieldChange(...)` returns true. The default `hasFieldChange` is:

```go
return resourceData.HasChange(field.fieldNameStr)
```

In the cases observed, `HasChange("user_data")` appears to be returning false for a real file content change — possibly an interaction with the `Base64StateFunc` `StateFunc` and the fact that `isBase64Encoded()` (lines 2380-2383) is a heuristic (`base64.StdEncoding.DecodeString(data) == nil`) that can return true for arbitrary plaintext that happens to be valid base64 alphabet + length-mod-4-zero. When a plaintext input is mistakenly identified as already-base64, `Base64StateFunc` stores the plaintext verbatim in state instead of re-encoding, which can confuse subsequent diff detection.

This PR does not attempt to fix the deeper `Base64StateFunc` heuristic — that change risks breaking existing state files. It targets only the symptom on the `user_data` field.

## Change

Install an explicit `hasChangeCustom` for the `UserData` field that always returns true when `user_data` is set in config. When `user_data` is unset in config it falls back to the default `HasChange` semantics, preserving the existing behavior for create-with-no-userdata flows.

```go
// before:
nil,

// after:
func(resourceData *schema.ResourceData, meta interface{}) bool {
 if v, ok := resourceData.Get(string(UserData)).(string); ok && v != "" {
 return true
 }
 return resourceData.HasChange(string(UserData))
},
```

Effect: when `user_data` is configured, it is always present in the body of the PATCH the provider sends to `PUT /ocean/aws/k8s/launchSpec/{id}`. The same SDK call (`launchSpec.SetUserData(...)`) that already runs in the `onUpdate` callback now runs unconditionally, so the API's write-path code is unchanged.

## Cost

When `user_data` is configured (the common case for production VNGs), every TF apply that touches the launch spec resource will include `user_data` in the PATCH body, even when its value is unchanged. This is one well-formed field per apply. The body is already being sent, so the only marginal cost is the bytes of the user_data payload. For ~15 KB of cloud-init this is negligible compared to the operational cost of the silent non-persist that the change prevents.

## Risk

Low. The change is additive (new `hasChangeCustom`), local to a single field, and the underlying SDK call is unchanged. Existing tests should continue to pass; a new acceptance test could be added that asserts `user_data` is always present in the captured PATCH body when configured.

## Alternatives considered

- **Fix `Base64StateFunc` / `isBase64Encoded` heuristic:** would address the suspected root cause but changes serialization semantics for existing state files; high risk of breaking users.
- **Apply the same hardening to other fields with the same shape (`labels`, `taints`, `tags`, etc.):** would be more robust but speculative without per-field reproductions.
- **Move `user_data` ownership out of the provider** (operator-side: a `null_resource` with `local-exec` calling `PUT /launchSpec/{id}/user_data`): a workaround we and other operators have used, but undesirable as a general answer.

A separate issue is being filed with the deeper trace and the suggestion to investigate `Base64StateFunc`.

## Compatibility

- No schema changes.
- No state migration.
- No new dependencies.
- Builds and `go vet` cleanly against current `main`.