### PR TITLE
fix(ocean/roll): Do not fail terraform apply on ocean clusters with 0 instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+BUG FIXES:
+* resource/spotinst_ocean_ecs: Treat the `CLUSTER_HAS_NO_ACTIVE_INSTANCES` API error during a roll as a no-op instead of failing the apply (clusters autoscaled to zero instances). Applied the same handling to the other Ocean roll paths (`spotinst_ocean_aws`, `spotinst_ocean_aws_launch_spec`, `spotinst_ocean_gke_import`, `spotinst_ocean_gke_launch_spec`, `spotinst_ocean_aks_np`, `spotinst_ocean_aks_np_virtual_node_group`).
 
 ## 1.238.0 (July, 2 2026)
 NOTES:

--- a/spotinst/resource_spotinst_ocean_aks_np.go
+++ b/spotinst/resource_spotinst_ocean_aks_np.go
@@ -256,6 +256,10 @@ func rollOceanAKSCluster(resourceData *schema.ResourceData, meta interface{}) er
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &azure_np.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderAzureNP().CreateRoll(context.TODO(), rollInput); err != nil {
+			if clusterHasNoActiveInstances(err) {
+				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+				return nil
+			}
 			return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 		}
 		log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)

--- a/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group.go
@@ -245,6 +245,10 @@ func rollOceanAKSVNG(resourceData *schema.ResourceData, meta interface{}) error 
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &azure_np.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderAzureNP().CreateRoll(context.TODO(), rollInput); err != nil {
+			if clusterHasNoActiveInstances(err) {
+				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+				return nil
+			}
 			return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 		}
 		log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)

--- a/spotinst/resource_spotinst_ocean_aws.go
+++ b/spotinst/resource_spotinst_ocean_aws.go
@@ -305,6 +305,10 @@ func rollOceanAWSCluster(resourceData *schema.ResourceData, meta interface{}) er
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &aws.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderAWS().CreateRoll(context.TODO(), rollInput); err != nil {
+			if clusterHasNoActiveInstances(err) {
+				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+				return nil
+			}
 			return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 		}
 		log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)

--- a/spotinst/resource_spotinst_ocean_aws_launch_spec.go
+++ b/spotinst/resource_spotinst_ocean_aws_launch_spec.go
@@ -233,6 +233,10 @@ func rollOceanAWSLaunchSpec(resourceData *schema.ResourceData, meta interface{})
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &aws.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderAWS().CreateRoll(context.TODO(), rollInput); err != nil {
+			if clusterHasNoActiveInstances(err) {
+				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+				return nil
+			}
 			return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 		}
 		log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)

--- a/spotinst/resource_spotinst_ocean_ecs.go
+++ b/spotinst/resource_spotinst_ocean_ecs.go
@@ -118,6 +118,25 @@ func createECSCluster(resourceData *schema.ResourceData, cluster *aws.ECSCluster
 
 const ErrCodeECSClusterNotFound = "CANT_GET_OCEAN_CLUSTER"
 
+// ErrCodeClusterHasNoActiveInstances is the Spotinst API error code returned
+// when a roll is requested on an Ocean cluster that currently has no active
+// instances (e.g. an autoscaled cluster with min_size = 0 scaled to zero).
+// Rolling such a cluster is a no-op rather than a failure.
+const ErrCodeClusterHasNoActiveInstances = "CLUSTER_HAS_NO_ACTIVE_INSTANCES"
+
+// clusterHasNoActiveInstances reports whether err is the Spotinst API error
+// returned when a roll is requested on a cluster that has no active instances.
+func clusterHasNoActiveInstances(err error) bool {
+	if errs, ok := err.(client.Errors); ok && len(errs) > 0 {
+		for _, e := range errs {
+			if e.Code == ErrCodeClusterHasNoActiveInstances {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func resourceSpotinstClusterECSRead(ctx context.Context, resourceData *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	id := resourceData.Id()
 	log.Printf(string(commons.ResourceOnRead),
@@ -247,6 +266,10 @@ func rollECSCluster(resourceData *schema.ResourceData, meta interface{}) error {
 						rollClusterInput.Roll.ClusterID = spotinst.String(clusterID)
 						_, err := meta.(*Client).ocean.CloudProviderAWS().RollECS(context.Background(), rollClusterInput)
 						if err != nil {
+							if clusterHasNoActiveInstances(err) {
+								log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+								return nil
+							}
 							return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 						} else {
 							log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)

--- a/spotinst/resource_spotinst_ocean_ecs_test.go
+++ b/spotinst/resource_spotinst_ocean_ecs_test.go
@@ -2,6 +2,7 @@ package spotinst
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/spotinst/spotinst-sdk-go/service/ocean/providers/aws"
 	"github.com/spotinst/spotinst-sdk-go/spotinst"
+	"github.com/spotinst/spotinst-sdk-go/spotinst/client"
 	"github.com/spotinst/terraform-provider-spotinst/spotinst/commons"
 )
 
@@ -1014,5 +1016,59 @@ const testLogging_Create = `
 `
 
 const testLogging_EmptyFields = ``
+
+// endregion
+
+// region OceanECS: Roll error handling
+
+func TestClusterHasNoActiveInstances(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+		{
+			name: "different API error code",
+			err:  client.Errors{{Code: ErrCodeECSClusterNotFound}},
+			want: false,
+		},
+		{
+			name: "matching code",
+			err:  client.Errors{{Code: ErrCodeClusterHasNoActiveInstances}},
+			want: true,
+		},
+		{
+			name: "matching code among others",
+			err: client.Errors{
+				{Code: "SOME_OTHER_CODE"},
+				{Code: ErrCodeClusterHasNoActiveInstances},
+			},
+			want: true,
+		},
+		{
+			name: "empty errors slice",
+			err:  client.Errors{},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clusterHasNoActiveInstances(tc.err); got != tc.want {
+				t.Errorf("clusterHasNoActiveInstances() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
 
 // endregion

--- a/spotinst/resource_spotinst_ocean_gke_import.go
+++ b/spotinst/resource_spotinst_ocean_gke_import.go
@@ -306,6 +306,10 @@ func rollOceanGKECluster(resourceData *schema.ResourceData, meta interface{}) er
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &gcp.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderGCP().CreateRoll(context.TODO(), rollInput); err != nil {
+			if clusterHasNoActiveInstances(err) {
+				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+				return nil
+			}
 			return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 		}
 		log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)

--- a/spotinst/resource_spotinst_ocean_gke_launch_spec.go
+++ b/spotinst/resource_spotinst_ocean_gke_launch_spec.go
@@ -277,6 +277,10 @@ func rollOceanGKELaunchSpec(resourceData *schema.ResourceData, meta interface{})
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &gcp.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderGCP().CreateRoll(context.TODO(), rollInput); err != nil {
+			if clusterHasNoActiveInstances(err) {
+				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+				return nil
+			}
 			return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 		}
 		log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)


### PR DESCRIPTION
Applying a change to a spotinst_ocean_ecs resource fails with:

Error: onRoll() -> Roll failed for cluster [o-xxxxxxxx], error: POST
 https://api.spotinst.io/ocean/aws/ecs/cluster/o-xxxxxxxx/roll?accountId=act-xxxxxxxx:
 400 (request: "...") CLUSTER_HAS_NO_ACTIVE_INSTANCES: Cluster has no active instances

This happens on autoscaled clusters with min_size = 0 that are scaled to zero at apply time. The cluster config update itself succeeds - only the subsequent roll fails, because rolling zero instances is rejected by the API.

This change catch this error.

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
