### PR TITLE
fix(ocean/roll): Added a fix to handle `terraform apply` on ocean clusters with 0 instances for AWS(cluster and vng), Azure(cluster and vng), GKE(import and launchspec) and ECS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 1.238.1 (July, 25 2026)
+## 1.238.1 (July, 27 2026)
 BUG FIXES:
 * resource/spotinst_ocean_aws: Added a fix to handle `terraform apply` on ocean clusters with 0 instances.
 * resource/spotinst_ocean_aws_launch_spec: Added a fix to handle `terraform apply` on ocean clusters with 0 instances.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+## 1.238.1 (July, 25 2026)
+BUG FIXES:
+* resource/spotinst_ocean_aws: Added a fix to handle `terraform apply` on ocean clusters with 0 instances.
+* resource/spotinst_ocean_aws_launch_spec: Added a fix to handle `terraform apply` on ocean clusters with 0 instances.
+* resource/spotinst_ocean_aks_np: Added a fix to handle `terraform apply` on ocean clusters with 0 instances.
+* resource/spotinst_ocean_aks_np_virtual_node_group: Added a fix to handle `terraform apply` on ocean clusters with 0 instances.
+* resource/spotinst_ocean_gke_launch_spec: Added a fix to handle `terraform apply` on ocean clusters with 0 instances.
+* resource/spotinst_ocean_gke_import: Added a fix to handle `terraform apply` on ocean clusters with 0 instances.
+* resource/spotinst_ocean_ecs: Added a fix to handle `terraform apply` on ocean clusters with 0 instances.
+
 ## 1.238.0 (July, 2 2026)
 NOTES:
 * Ocean_Spark: Decommissioned SDK code and removed components in terraform-provider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 1.238.1 (July, 27 2026)
+## 1.238.1 (July, 29 2026)
 BUG FIXES:
 * resource/spotinst_ocean_aws: Added a fix to handle `terraform apply` on ocean clusters with 0 instances.
 * resource/spotinst_ocean_aws_launch_spec: Added a fix to handle `terraform apply` on ocean clusters with 0 instances.

--- a/spotinst/commons/common_spotinst_resource.go
+++ b/spotinst/commons/common_spotinst_resource.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/spotinst/spotinst-sdk-go/spotinst/client"
 )
 
 // GenerateSecureRandomInt generates a secure random integer between min and max using crypto/rand
@@ -140,4 +141,23 @@ func ToJson(object interface{}) (string, error) {
 	} else {
 		return string(bytes), nil
 	}
+}
+
+// ErrCodeClusterHasNoActiveInstances is the Spotinst API error code returned
+// when a roll is requested on an Ocean cluster that currently has no active
+// instances (e.g. an autoscaled cluster with min_size = 0 scaled to zero).
+// Rolling such a cluster is a no-op rather than a failure.
+const ErrCodeClusterHasNoActiveInstances = "CLUSTER_HAS_NO_ACTIVE_INSTANCES"
+
+// clusterHasNoActiveInstances reports whether err is the Spotinst API error
+// returned when a roll is requested on a cluster that has no active instances.
+func ClusterHasNoActiveInstances(err error) bool {
+	if errs, ok := err.(client.Errors); ok && len(errs) > 0 {
+		for _, e := range errs {
+			if e.Code == ErrCodeClusterHasNoActiveInstances {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/spotinst/resource_spotinst_ocean_aks_np.go
+++ b/spotinst/resource_spotinst_ocean_aks_np.go
@@ -256,6 +256,10 @@ func rollOceanAKSCluster(resourceData *schema.ResourceData, meta interface{}) er
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &azure_np.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderAzureNP().CreateRoll(context.TODO(), rollInput); err != nil {
+			if clusterHasNoActiveInstances(err) {
+				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+				return nil
+			}
 			return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 		}
 		log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)

--- a/spotinst/resource_spotinst_ocean_aks_np.go
+++ b/spotinst/resource_spotinst_ocean_aks_np.go
@@ -256,7 +256,7 @@ func rollOceanAKSCluster(resourceData *schema.ResourceData, meta interface{}) er
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &azure_np.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderAzureNP().CreateRoll(context.TODO(), rollInput); err != nil {
-			if clusterHasNoActiveInstances(err) {
+			if commons.ClusterHasNoActiveInstances(err) {
 				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
 				return nil
 			}

--- a/spotinst/resource_spotinst_ocean_aks_np_test.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_test.go
@@ -223,7 +223,7 @@ func TestAccSpotinstOceanAKSNP_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "os_disk_type", "Managed"),
 					resource.TestCheckResourceAttr(resourceName, "os_type", "Linux"),
 					resource.TestCheckResourceAttr(resourceName, "os_sku", "Ubuntu"),
-					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.33"),
+					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.34"),
 					resource.TestCheckResourceAttr(resourceName, "spot_percentage", "50"),
 					resource.TestCheckResourceAttr(resourceName, "fallback_to_ondemand", "false"),
 					resource.TestCheckResourceAttr(resourceName, "should_utilize_commitments", "false"),
@@ -251,7 +251,7 @@ func TestAccSpotinstOceanAKSNP_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_pods_per_node", "50"),
 					resource.TestCheckResourceAttr(resourceName, "enable_node_public_ip", "true"),
 					resource.TestCheckResourceAttr(resourceName, "os_disk_size_gb", "64"),
-					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.33"),
+					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.34"),
 					resource.TestCheckResourceAttr(resourceName, "spot_percentage", "100"),
 					resource.TestCheckResourceAttr(resourceName, "fallback_to_ondemand", "true"),
 					resource.TestCheckResourceAttr(resourceName, "should_utilize_commitments", "true"),
@@ -297,7 +297,7 @@ resource "` + string(commons.OceanAKSNPResourceName) + `" "%v" {
   os_disk_type          = "Managed"
   os_type               = "Linux"
   os_sku                = "Ubuntu"
-  kubernetes_version    = "1.33"
+  kubernetes_version    = "1.34"
   //vnet_subnet_ids       = ["/subscriptions/a9e813ad-f18b-4ad2-9dbc-5c6df28e9cb8/resourceGroups/AutomationResourceGroup/providers/Microsoft.Network/virtualNetworks/Automation-VirtualNetwork/subnets/default"]
   // ----------------------------------------------------------------------
   linux_os_config {
@@ -357,7 +357,7 @@ resource "` + string(commons.OceanAKSNPResourceName) + `" "%v" {
   os_disk_type          = "Managed"
   os_type               = "Linux"
   os_sku                = "Ubuntu"
-  kubernetes_version    = "1.33"
+  kubernetes_version    = "1.34"
   //vnet_subnet_ids       = ["/subscriptions/a9e813ad-f18b-4ad2-9dbc-5c6df28e9cb8/resourceGroups/AutomationResourceGroup/providers/Microsoft.Network/virtualNetworks/Automation-VirtualNetwork/subnets/default"]
   // ----------------------------------------------------------------------
   linux_os_config {

--- a/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group.go
@@ -245,6 +245,10 @@ func rollOceanAKSVNG(resourceData *schema.ResourceData, meta interface{}) error 
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &azure_np.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderAzureNP().CreateRoll(context.TODO(), rollInput); err != nil {
+			if clusterHasNoActiveInstances(err) {
+				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+				return nil
+			}
 			return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 		}
 		log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)

--- a/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group.go
@@ -245,7 +245,7 @@ func rollOceanAKSVNG(resourceData *schema.ResourceData, meta interface{}) error 
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &azure_np.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderAzureNP().CreateRoll(context.TODO(), rollInput); err != nil {
-			if clusterHasNoActiveInstances(err) {
+			if commons.ClusterHasNoActiveInstances(err) {
 				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
 				return nil
 			}

--- a/spotinst/resource_spotinst_ocean_aws.go
+++ b/spotinst/resource_spotinst_ocean_aws.go
@@ -305,6 +305,10 @@ func rollOceanAWSCluster(resourceData *schema.ResourceData, meta interface{}) er
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &aws.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderAWS().CreateRoll(context.TODO(), rollInput); err != nil {
+			if clusterHasNoActiveInstances(err) {
+				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+				return nil
+			}
 			return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 		}
 		log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)

--- a/spotinst/resource_spotinst_ocean_aws.go
+++ b/spotinst/resource_spotinst_ocean_aws.go
@@ -305,7 +305,7 @@ func rollOceanAWSCluster(resourceData *schema.ResourceData, meta interface{}) er
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &aws.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderAWS().CreateRoll(context.TODO(), rollInput); err != nil {
-			if clusterHasNoActiveInstances(err) {
+			if commons.ClusterHasNoActiveInstances(err) {
 				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
 				return nil
 			}

--- a/spotinst/resource_spotinst_ocean_aws_launch_spec.go
+++ b/spotinst/resource_spotinst_ocean_aws_launch_spec.go
@@ -233,6 +233,10 @@ func rollOceanAWSLaunchSpec(resourceData *schema.ResourceData, meta interface{})
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &aws.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderAWS().CreateRoll(context.TODO(), rollInput); err != nil {
+			if clusterHasNoActiveInstances(err) {
+				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+				return nil
+			}
 			return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 		}
 		log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)

--- a/spotinst/resource_spotinst_ocean_aws_launch_spec.go
+++ b/spotinst/resource_spotinst_ocean_aws_launch_spec.go
@@ -233,7 +233,7 @@ func rollOceanAWSLaunchSpec(resourceData *schema.ResourceData, meta interface{})
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &aws.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderAWS().CreateRoll(context.TODO(), rollInput); err != nil {
-			if clusterHasNoActiveInstances(err) {
+			if commons.ClusterHasNoActiveInstances(err) {
 				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
 				return nil
 			}

--- a/spotinst/resource_spotinst_ocean_ecs.go
+++ b/spotinst/resource_spotinst_ocean_ecs.go
@@ -118,6 +118,25 @@ func createECSCluster(resourceData *schema.ResourceData, cluster *aws.ECSCluster
 
 const ErrCodeECSClusterNotFound = "CANT_GET_OCEAN_CLUSTER"
 
+// ErrCodeClusterHasNoActiveInstances is the Spotinst API error code returned
+// when a roll is requested on an Ocean cluster that currently has no active
+// instances (e.g. an autoscaled cluster with min_size = 0 scaled to zero).
+// Rolling such a cluster is a no-op rather than a failure.
+const ErrCodeClusterHasNoActiveInstances = "CLUSTER_HAS_NO_ACTIVE_INSTANCES"
+
+// clusterHasNoActiveInstances reports whether err is the Spotinst API error
+// returned when a roll is requested on a cluster that has no active instances.
+func clusterHasNoActiveInstances(err error) bool {
+	if errs, ok := err.(client.Errors); ok && len(errs) > 0 {
+		for _, e := range errs {
+			if e.Code == ErrCodeClusterHasNoActiveInstances {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func resourceSpotinstClusterECSRead(ctx context.Context, resourceData *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	id := resourceData.Id()
 	log.Printf(string(commons.ResourceOnRead),
@@ -247,6 +266,10 @@ func rollECSCluster(resourceData *schema.ResourceData, meta interface{}) error {
 						rollClusterInput.Roll.ClusterID = spotinst.String(clusterID)
 						_, err := meta.(*Client).ocean.CloudProviderAWS().RollECS(context.Background(), rollClusterInput)
 						if err != nil {
+							if clusterHasNoActiveInstances(err) {
+								log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+								return nil
+							}
 							return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 						} else {
 							log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)

--- a/spotinst/resource_spotinst_ocean_ecs.go
+++ b/spotinst/resource_spotinst_ocean_ecs.go
@@ -118,25 +118,6 @@ func createECSCluster(resourceData *schema.ResourceData, cluster *aws.ECSCluster
 
 const ErrCodeECSClusterNotFound = "CANT_GET_OCEAN_CLUSTER"
 
-// ErrCodeClusterHasNoActiveInstances is the Spotinst API error code returned
-// when a roll is requested on an Ocean cluster that currently has no active
-// instances (e.g. an autoscaled cluster with min_size = 0 scaled to zero).
-// Rolling such a cluster is a no-op rather than a failure.
-const ErrCodeClusterHasNoActiveInstances = "CLUSTER_HAS_NO_ACTIVE_INSTANCES"
-
-// clusterHasNoActiveInstances reports whether err is the Spotinst API error
-// returned when a roll is requested on a cluster that has no active instances.
-func clusterHasNoActiveInstances(err error) bool {
-	if errs, ok := err.(client.Errors); ok && len(errs) > 0 {
-		for _, e := range errs {
-			if e.Code == ErrCodeClusterHasNoActiveInstances {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 func resourceSpotinstClusterECSRead(ctx context.Context, resourceData *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	id := resourceData.Id()
 	log.Printf(string(commons.ResourceOnRead),
@@ -266,7 +247,7 @@ func rollECSCluster(resourceData *schema.ResourceData, meta interface{}) error {
 						rollClusterInput.Roll.ClusterID = spotinst.String(clusterID)
 						_, err := meta.(*Client).ocean.CloudProviderAWS().RollECS(context.Background(), rollClusterInput)
 						if err != nil {
-							if clusterHasNoActiveInstances(err) {
+							if commons.ClusterHasNoActiveInstances(err) {
 								log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
 								return nil
 							}

--- a/spotinst/resource_spotinst_ocean_gke_import.go
+++ b/spotinst/resource_spotinst_ocean_gke_import.go
@@ -306,6 +306,10 @@ func rollOceanGKECluster(resourceData *schema.ResourceData, meta interface{}) er
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &gcp.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderGCP().CreateRoll(context.TODO(), rollInput); err != nil {
+			if clusterHasNoActiveInstances(err) {
+				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+				return nil
+			}
 			return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 		}
 		log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)

--- a/spotinst/resource_spotinst_ocean_gke_import.go
+++ b/spotinst/resource_spotinst_ocean_gke_import.go
@@ -306,7 +306,7 @@ func rollOceanGKECluster(resourceData *schema.ResourceData, meta interface{}) er
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &gcp.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderGCP().CreateRoll(context.TODO(), rollInput); err != nil {
-			if clusterHasNoActiveInstances(err) {
+			if commons.ClusterHasNoActiveInstances(err) {
 				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
 				return nil
 			}

--- a/spotinst/resource_spotinst_ocean_gke_launch_spec.go
+++ b/spotinst/resource_spotinst_ocean_gke_launch_spec.go
@@ -277,6 +277,10 @@ func rollOceanGKELaunchSpec(resourceData *schema.ResourceData, meta interface{})
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &gcp.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderGCP().CreateRoll(context.TODO(), rollInput); err != nil {
+			if clusterHasNoActiveInstances(err) {
+				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
+				return nil
+			}
 			return fmt.Errorf("onRoll() -> Roll failed for cluster [%v], error: %v", clusterID, err)
 		}
 		log.Printf("onRoll() -> Successfully rolled cluster [%v]", clusterID)

--- a/spotinst/resource_spotinst_ocean_gke_launch_spec.go
+++ b/spotinst/resource_spotinst_ocean_gke_launch_spec.go
@@ -277,7 +277,7 @@ func rollOceanGKELaunchSpec(resourceData *schema.ResourceData, meta interface{})
 		log.Printf("onRoll() -> Rolling cluster [%v] with configuration %s", clusterID, rollJSON)
 		rollInput := &gcp.CreateRollInput{Roll: rollSpec}
 		if _, err = meta.(*Client).ocean.CloudProviderGCP().CreateRoll(context.TODO(), rollInput); err != nil {
-			if clusterHasNoActiveInstances(err) {
+			if commons.ClusterHasNoActiveInstances(err) {
 				log.Printf("onRoll() -> cluster [%v] has no active instances, nothing to roll", clusterID)
 				return nil
 			}


### PR DESCRIPTION
Added a fix to handle `terraform apply` on ocean clusters with 0 instances for AWS(cluster and vng), Azure(cluster and vng), GKE(import and launchspec) and ECS.

https://flexera.atlassian.net/browse/SOD-8035