### PR TITLE
fix(ocean): surface block_device_mappings drift when API returns null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## Unreleased
+BUG FIXES:
+* resource/spotinst_ocean_aws: Fixed `block_device_mappings` not showing drift when the API returns null (e.g. after a `root_volume_size` update).
+* resource/spotinst_ocean_aws_launch_spec: Fixed `block_device_mappings` not showing drift when the API returns null.
+* resource/spotinst_ocean_ecs: Fixed `block_device_mappings` not showing drift when the API returns null.
+* resource/spotinst_ocean_ecs_launch_spec: Fixed `block_device_mappings` not showing drift when the API returns null.
 
 ## 1.240.0 (August, 14 2026)
 ENHANCEMENTS:

--- a/spotinst/ocean_aws_launch_configuration/fields_spotinst_ocean_aws_launch_configuration.go
+++ b/spotinst/ocean_aws_launch_configuration/fields_spotinst_ocean_aws_launch_configuration.go
@@ -800,10 +800,8 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				result = flattenBlockDeviceMappings(cluster.Compute.LaunchSpecification.BlockDeviceMappings)
 			}
 
-			if len(result) > 0 {
-				if err := resourceData.Set(string(BlockDeviceMappings), result); err != nil {
-					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(BlockDeviceMappings), err)
-				}
+			if err := resourceData.Set(string(BlockDeviceMappings), result); err != nil {
+				return fmt.Errorf(string(commons.FailureFieldReadPattern), string(BlockDeviceMappings), err)
 			}
 			return nil
 		},

--- a/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
+++ b/spotinst/ocean_aws_launch_spec/fields_spotinst_ocean_aws_launch_spec.go
@@ -617,10 +617,8 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				result = flattenBlockDeviceMappings(launchSpec.BlockDeviceMappings)
 			}
 
-			if len(result) > 0 {
-				if err := resourceData.Set(string(BlockDeviceMappings), result); err != nil {
-					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(BlockDeviceMappings), err)
-				}
+			if err := resourceData.Set(string(BlockDeviceMappings), result); err != nil {
+				return fmt.Errorf(string(commons.FailureFieldReadPattern), string(BlockDeviceMappings), err)
 			}
 			return nil
 		},

--- a/spotinst/ocean_ecs_launch_spec/fields_spotinst_ocean_ecs_launch_spec.go
+++ b/spotinst/ocean_ecs_launch_spec/fields_spotinst_ocean_ecs_launch_spec.go
@@ -656,10 +656,8 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				result = flattenBlockDeviceMappings(launchSpec.BlockDeviceMappings)
 			}
 
-			if len(result) > 0 {
-				if err := resourceData.Set(string(BlockDeviceMappings), result); err != nil {
-					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(BlockDeviceMappings), err)
-				}
+			if err := resourceData.Set(string(BlockDeviceMappings), result); err != nil {
+				return fmt.Errorf(string(commons.FailureFieldReadPattern), string(BlockDeviceMappings), err)
 			}
 			return nil
 		},

--- a/spotinst/ocean_ecs_launch_specification/fields_spotinst_ocean_ecs_launch_specification.go
+++ b/spotinst/ocean_ecs_launch_specification/fields_spotinst_ocean_ecs_launch_specification.go
@@ -555,10 +555,8 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 				result = flattenBlockDeviceMappings(cluster.Compute.LaunchSpecification.BlockDeviceMappings)
 			}
 
-			if len(result) > 0 {
-				if err := resourceData.Set(string(BlockDeviceMappings), result); err != nil {
-					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(BlockDeviceMappings), err)
-				}
+			if err := resourceData.Set(string(BlockDeviceMappings), result); err != nil {
+				return fmt.Errorf(string(commons.FailureFieldReadPattern), string(BlockDeviceMappings), err)
 			}
 			return nil
 		},


### PR DESCRIPTION
Fixes #699.

## Problem

When the Spot API returns `blockDeviceMappings: null` for an Ocean cluster or
launch spec, `terraform plan` shows "No changes" forever even though the live
resource no longer has the configured mappings.

The backend produces this state as a side effect of a `rootVolumeSize` update:
`rootVolumeSize` and `blockDeviceMappings` are mutually exclusive, so setting
the former nulls the latter. From then on, refresh silently keeps the stale
`block_device_mappings` in state and the drift is invisible.

## Root cause

The OnRead handler for `BlockDeviceMappings` only calls `resourceData.Set()`
when the flattened result is non-empty:

```go
if len(result) > 0 {
    if err := resourceData.Set(string(BlockDeviceMappings), result); err != nil {
        ...
    }
}
```

When the API returns null, `result` is nil, Set is never called, and state
keeps whatever was there before.

## Change

Call `resourceData.Set()` unconditionally, writing an empty list when the API
returns null — the same idiom `load_balancer` (same file), `whitelist`, and
`blacklist` already use. Applied to all four Ocean resources that share the
skip-Set-on-null pattern for this field:

- `spotinst_ocean_aws` (launch configuration)
- `spotinst_ocean_aws_launch_spec`
- `spotinst_ocean_ecs` (launch specification)
- `spotinst_ocean_ecs_launch_spec`

No spurious diffs for users who never set `block_device_mappings`: the field
is Optional (not Computed) at the top level, so an empty list in state and an
absent block in config compare equal — identical to the long-standing
`load_balancer` behavior.

## Behavior change

Users whose config still declares `block_device_mappings` while the API holds
null (e.g. after a `root_volume_size` update) will now correctly see the drift
in `terraform plan` instead of a silent no-op. Configs that set both
`root_volume_size` and `block_device_mappings` (mutually exclusive on the
backend) will show perpetual drift until one is removed — surfacing a real
conflict that was previously hidden.

## Compatibility

- No schema changes, no state migration, no new dependencies.
- `go build ./...`, `go vet`, `gofmt` clean. CHANGELOG entry included.
- The field packages contain no unit tests (acceptance tests only); happy to
  add coverage if you can point me at a preferred harness for OnRead handlers.
