### PR TITLE
feat(ocean RightSizingRule): Added support for CpuPercentile and MemoryPercentile field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 1.241.0 (August, 20 2026)
+ENHANCEMENTS:
+* resource/spotinst_ocean_right_sizing_rule: Added support for `cpu_percentile` and `memory_percentile` field.
+* resource/spotinst_ocean_aks_np: Added support for `local_dns_profile` field.
+* resource/spotinst_ocean_aks_np_virtual_node_group: Added support for `local_dns_profile` field.
+
 ## 1.240.0 (August, 14 2026)
 ENHANCEMENTS:
 * resource/spotinst_ocean_gke_launch_spec: Added support for `scheduling_shutdown_hours` field.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## Unreleased
 
-## 1.241.0 (August, 20 2026)
+## 1.241.0 (August, 25 2026)
 ENHANCEMENTS:
 * resource/spotinst_ocean_right_sizing_rule: Added support for `cpu_percentile` and `memory_percentile` field.
-* resource/spotinst_ocean_aks_np: Added support for `local_dns_profile` and `encryption_at_host` fields.
-* resource/spotinst_ocean_aks_np_virtual_node_group: Added support for `local_dns_profile` and `encryption_at_host` fields.
+* resource/spotinst_ocean_aks_np: Added support for `local_dns_profile`, `encryption_at_host` and `preferred_vm_sizes` fields.
+* resource/spotinst_ocean_aks_np_virtual_node_group: Added support for `local_dns_profile`, `encryption_at_host` and `preferred_vm_sizes` fields.
 * resource/spotinst_elastigroup_azure_v3: Added support for `license_type` object.
 
 ## 1.240.0 (August, 14 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 1.241.0 (August, 20 2026)
 ENHANCEMENTS:
 * resource/spotinst_ocean_right_sizing_rule: Added support for `cpu_percentile` and `memory_percentile` field.
-* resource/spotinst_ocean_aks_np: Added support for `local_dns_profile` field.
-* resource/spotinst_ocean_aks_np_virtual_node_group: Added support for `local_dns_profile` field.
+* resource/spotinst_ocean_aks_np: Added support for `local_dns_profile` and `encryption_at_host` fields.
+* resource/spotinst_ocean_aks_np_virtual_node_group: Added support for `local_dns_profile` and `encryption_at_host` fields.
 
 ## 1.240.0 (August, 14 2026)
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ENHANCEMENTS:
 * resource/spotinst_ocean_right_sizing_rule: Added support for `cpu_percentile` and `memory_percentile` field.
 * resource/spotinst_ocean_aks_np: Added support for `local_dns_profile` and `encryption_at_host` fields.
 * resource/spotinst_ocean_aks_np_virtual_node_group: Added support for `local_dns_profile` and `encryption_at_host` fields.
+* resource/spotinst_elastigroup_azure_v3: Added support for `license_type` object.
 
 ## 1.240.0 (August, 14 2026)
 ENHANCEMENTS:

--- a/docs/resources/elastigroup_azure.md
+++ b/docs/resources/elastigroup_azure.md
@@ -52,6 +52,7 @@ resource "spotinst_elastigroup_azure_v3" "test_azure_group" {
   //user_data = "IlRlc3RpbmcgRUci"
   
   vm_name_prefix = "prefixName"
+  license_type = "Windows_Server"
   
   managed_service_identity {
   resource_group_name = "MC_ocean-westus-dev_ocean-westus-dev-aks_westus"
@@ -243,6 +244,7 @@ The following arguments are supported:
 * `user_data` - (Optional) Define a set of scripts or other metadata that's inserted to an Azure virtual machine at provision time. Cannot be defined along with `custom_data`.
 * `shutdown_script` - (Optional) Shutdown script for the group. Value should be passed as a string encoded at Base64 only.
 * `vm_name_prefix` - (Optional) Set a VM name prefix to be used for all launched VMs and the VM resources.
+* `license_type` - (Optional) Enables Azure Hybrid Benefit for the Elastigroup. Accepted values: `Windows_Client`, `Windows_Server`, `RHEL_BYOS`, `SLES_BYOS`.
 * `zones` - (Optional) List of Azure Availability Zones in the defined region; If not defined, Virtual machines will be launched regionally.
 * `preferred_zones` - (Optional) The AZs to prioritize when launching VMs. If no markets are available in the Preferred AZs, VMs are launched in the non-preferred AZs. Must be a sublist of `zones`.
 * `managed_service_identity` - (Optional) List of Managed Service Identity objects.

--- a/docs/resources/ocean_aks_np.md
+++ b/docs/resources/ocean_aks_np.md
@@ -168,6 +168,57 @@ resource "spotinst_ocean_aks_np" "example" {
   }
   // ----------------------------------------------------------------------
 
+  // --- LocalDnsProfile --------------------------------------------------
+
+  local_dns_profile {
+    mode = "Required"
+    vnet_dns_overrides {
+      zone                            = "."
+      query_logging                   = "Error"
+      protocol                        = "PreferUDP"
+      forward_destination             = "VnetDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+    vnet_dns_overrides {
+      zone                            = "cluster.local"
+      query_logging                   = "Error"
+      protocol                        = "ForceTCP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+    kube_dns_overrides {
+      zone                            = "."
+      query_logging                   = "Error"
+      protocol                        = "PreferUDP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+    kube_dns_overrides {
+      zone                            = "cluster.local"
+      query_logging                   = "Error"
+      protocol                        = "ForceTCP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+  }
+  // ----------------------------------------------------------------------
+  
   // --- strategy ---------------------------------------------------------
   
   spot_percentage             = 50
@@ -281,6 +332,19 @@ The following arguments are supported:
 * `kubernetes_version` - (Optional) The desired Kubernetes version of the launched nodes. In case the value is null, the Kubernetes version of the control plane is used.
 * `fallback_to_ondemand` - (Optional) If no spot VM markets are available, enable Ocean to launch regular (pay-as-you-go) nodes instead.
 * `draining_timeout` - (Optional) Time in seconds to allow the node to drain before it is terminated. The parameter value will be in range `[300-3600]`.
+* `local_dns_profile` - (Optional) Local DNS profile configuration for the node pool. Requires VM sizes with at least 4 vCPUs and Linux (Ubuntu 22.04+ or Azure Linux) OS. See: [AKS Local DNS Custom Field](https://learn.microsoft.com/en-us/azure/aks/localdns-custom).
+  * `mode` - (Required) The LocalDNS mode. Required when localDnsProfile is configured. Allowed values: `"Required"`, `"Preferred"`, `"Disabled"`.
+  * `vnet_dns_overrides` - (Optional) Per-zone DNS override configuration for VNet DNS resolution. Keys are DNS zone names (`"."` or `"cluster.local"`).
+    * `zone` - (Required) The DNS zone name this override applies to (`"."`, `"cluster.local"`).
+    * `query_logging` - (Optional) Define the logging level for DNS queries. Allowed values: `"Error"`, `"Log"`.
+    * `protocol` - (Optional) Sets the protocol used for DNS queries (UDP/TCP preference). Allowed values: `"PreferUDP"`, `"ForceTCP"`.
+    * `forward_destination` - (Optional) Specifies the DNS server to forward queries to. Allowed values:  `"VnetDNS"`, `"ClusterCoreDNS"`.
+    * `forward_policy` - (Optional) Determines the policy to use when selecting the upstream DNS server. Allowed values:  `"Sequential"`, `"RoundRobin"`, `"Random"`.
+    * `max_concurrent` - (Optional) Maximum number of concurrent DNS queries handled by LocalDNS.
+    * `cache_duration_in_seconds` - (Optional) Maximum TTL (Time To Live) in seconds for which DNS responses are cached.
+    * `serve_stale_duration_in_seconds` - (Optional) Duration (in seconds) to serve stale DNS responses if upstream is unavailable.
+    * `serve_stale` - (Optional) Policy for serving stale DNS responses during upstream failures. Allowed values: `"Immediate"`, `"Verify"`, `"Disabled"`.
+  * `kube_dns_overrides` - (Optional) Per-zone DNS override configuration for kube-dns/CoreDNS resolution. Keys are DNS zone names (e.g. `"."` or `"cluster.local"`) and all values are same as `vnet_dns_overrides`. 
 * `spot_percentage` - (Optional) Percentage of spot VMs to maintain.
 * `should_utilize_commitments` - (Optional, Default: `false`) Determines whether to utilize any existing Azure Savings Plans or Reserved Instances associated with the subscription for On-Demand VMs.
 * `tag` - (Optional) A maximum of 10 unique key-value pairs for VM tags in the virtual node group.

--- a/docs/resources/ocean_aks_np.md
+++ b/docs/resources/ocean_aks_np.md
@@ -154,6 +154,7 @@ resource "spotinst_ocean_aks_np" "example" {
   
   max_pods_per_node     = 30
   enable_node_public_ip = true
+  encryption_at_host    = true
   os_disk_size_gb       = 30
   os_disk_type          = "Managed"
   os_type               = "Windows"
@@ -319,6 +320,7 @@ The following arguments are supported:
 * `max_count` - (Optional, Default: 1000) Maximum node count limit.
 * `min_count` - (Optional, Default: 0) Minimum node count limit.
 * `enable_node_public_ip` - (Optional) Enable node public IP.
+* `encryption_at_host` - (Optional, Default: `false`) Whether to enable host-based encryption for nodes. When set to `true`, use `vmSizes.preferredVmSizes` to provide compatible VM sizes. **Important:** This setting is immutable at the Azure infrastructure level once nodes are launched. Changing this value requires a roll operation for new nodes to reflect the updated configuration.
 * `max_pods_per_node` - (Optional) The maximum number of pods per node in the node pools.
 * `os_disk_size_gb` - (Optional) The size of the OS disk in GB.
 * `os_disk_type` - (Optional, Enum:`"Managed" ,"Ephemeral"`) The type of the OS disk.

--- a/docs/resources/ocean_aks_np.md
+++ b/docs/resources/ocean_aks_np.md
@@ -268,6 +268,8 @@ resource "spotinst_ocean_aks_np" "example" {
     min_disk               = 1
     gpu_types              = ["nvidia-tesla-t4"]
   }
+
+  preferred_vm_sizes = ["Standard_D4s_v3", "Standard_D8s_v3"]
   
   // ----------------------------------------------------------------------
 }
@@ -372,6 +374,7 @@ The following arguments are supported:
   * `min_disk` - (Optional) Minimum number of data disks available.
   * `vm_types` - (Optional, Enum `"generalPurpose", "memoryOptimized", "computeOptimized", "highPerformanceCompute", "storageOptimized", "GPU"`) The filtered vm types will belong to one of the vm types from this list.
   * `gpu_types` - (Optional, Enum `"nvidia-tesla-v100", "amd-radeon-instinct-mi25", "nvidia-a10", "nvidia-tesla-a100", "nvidia-tesla-k80", "nvidia-tesla-m60", "nvidia-tesla-p100", "nvidia-tesla-p40", "nvidia-tesla-t4", "nvidia-tesla-h100"`) The filtered gpu types will belong to one of the gpu types from this list.
+* `preferred_vm_sizes` - (Optional) Preferred VM sizes for this virtual node group. Used when nodePoolProperties.encryptionAtHost is true to constrain launches to compatible sizes.
 * `logging` - (Optional) The Ocean AKS Logging Object.
   * `export` - The Ocean AKS Logging Export object.
     * `azure_blob` -  Exports your cluster's logs to the storage account and container configured on the storage account [data integration](https://docs.spot.io/ocean/features/log-integration-with-azure-blob?id=log-integration-with-azure-blob) given. Each file contains logs of 3 minutes where each log is separated by a new line and saved as a JSON. The file formats are `container`/`accountId``oceanId``oceanName`_`startTime`.log

--- a/docs/resources/ocean_aks_np_virtual_node_group.md
+++ b/docs/resources/ocean_aks_np_virtual_node_group.md
@@ -65,6 +65,57 @@ resource "spotinst_ocean_aks_np_virtual_node_group" "example" {
   }
 
   // --------------------------------------------------------------------------
+  
+  // --- LocalDnsProfile --------------------------------------------------
+
+  local_dns_profile {
+    mode = "Required"
+    vnet_dns_overrides {
+      zone                            = "."
+      query_logging                   = "Error"
+      protocol                        = "PreferUDP"
+      forward_destination             = "VnetDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+    vnet_dns_overrides {
+      zone                            = "cluster.local"
+      query_logging                   = "Error"
+      protocol                        = "ForceTCP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+    kube_dns_overrides {
+      zone                            = "."
+      query_logging                   = "Error"
+      protocol                        = "PreferUDP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+    kube_dns_overrides {
+      zone                            = "cluster.local"
+      query_logging                   = "Error"
+      protocol                        = "ForceTCP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+  }
+  // ----------------------------------------------------------------------
 
   // --- strategy -------------------------------------------------------------
   
@@ -162,6 +213,19 @@ The following arguments are supported:
     * `vm_max_map_count` - (Optional) Maximum number of memory map areas a process may have. Can be configured only if OS type is Linux.
 * `fallback_to_ondemand` - (Optional) If no spot instance markets are available, enable Ocean to launch on-demand instances instead.
 * `draining_timeout` - (Optional) Time in seconds to allow the node to drain before it is terminated. The parameter value will be in range `[300-3600]`.
+* `local_dns_profile` - (Optional) Local DNS profile configuration for the node pool. Requires VM sizes with at least 4 vCPUs and Linux (Ubuntu 22.04+ or Azure Linux) OS. See: [AKS Local DNS Custom Field](https://learn.microsoft.com/en-us/azure/aks/localdns-custom).
+  * `mode` - (Required) The LocalDNS mode. Required when localDnsProfile is configured. Allowed values: `"Required"`, `"Preferred"`, `"Disabled"`.
+  * `vnet_dns_overrides` - (Optional) Per-zone DNS override configuration for VNet DNS resolution. Keys are DNS zone names (`"."` or `"cluster.local"`).
+    * `zone` - (Required) The DNS zone name this override applies to (`"."`, `"cluster.local"`).
+    * `query_logging` - (Optional) Define the logging level for DNS queries. Allowed values: `"Error"`, `"Log"`.
+    * `protocol` - (Optional) Sets the protocol used for DNS queries (UDP/TCP preference). Allowed values: `"PreferUDP"`, `"ForceTCP"`.
+    * `forward_destination` - (Optional) Specifies the DNS server to forward queries to. Allowed values:  `"VnetDNS"`, `"ClusterCoreDNS"`.
+    * `forward_policy` - (Optional) Determines the policy to use when selecting the upstream DNS server. Allowed values:  `"Sequential"`, `"RoundRobin"`, `"Random"`.
+    * `max_concurrent` - (Optional) Maximum number of concurrent DNS queries handled by LocalDNS.
+    * `cache_duration_in_seconds` - (Optional) Maximum TTL (Time To Live) in seconds for which DNS responses are cached.
+    * `serve_stale_duration_in_seconds` - (Optional) Duration (in seconds) to serve stale DNS responses if upstream is unavailable.
+    * `serve_stale` - (Optional) Policy for serving stale DNS responses during upstream failures. Allowed values: `"Immediate"`, `"Verify"`, `"Disabled"`.
+  * `kube_dns_overrides` - (Optional) Per-zone DNS override configuration for kube-dns/CoreDNS resolution. Keys are DNS zone names (e.g. `"."` or `"cluster.local"`) and all values are same as `vnet_dns_overrides`.
 * `spot_percentage` - (Optional) Percentage of spot VMs to maintain.
 * `should_utilize_commitments` - (Optional, Default: `false`) Determines whether to utilize any existing Azure Savings Plans or Reserved Instances associated with the subscription for On-Demand VMs.
 * `restrict_scale_down` - (Optional, Default: `false`) When set to `true`, nodes in this VNG will be protected from scale-down as long as they have reschedulable workloads running.

--- a/docs/resources/ocean_aks_np_virtual_node_group.md
+++ b/docs/resources/ocean_aks_np_virtual_node_group.md
@@ -51,6 +51,7 @@ resource "spotinst_ocean_aks_np_virtual_node_group" "example" {
   
   max_pods_per_node     = 30
   enable_node_public_ip = true
+  encryption_at_host    = true
   os_disk_size_gb       = 30
   os_disk_type          = "Managed"
   os_type               = "Linux"
@@ -200,6 +201,7 @@ The following arguments are supported:
 * `max_count` - (Optional, Default: 1000) Maximum node count limit.
 * `min_count` - (Optional, Default: 0) Minimum node count limit.
 * `enable_node_public_ip` - (Optional) Enable node public IP.
+* `encryption_at_host` - (Optional, Default: `false`) Whether to enable host-based encryption for nodes. When set to `true`, use `vmSizes.preferredVmSizes` to provide compatible VM sizes. **Important:** This setting is immutable at the Azure infrastructure level once nodes are launched. Changing this value requires a roll operation for new nodes to reflect the updated configuration.
 * `max_pods_per_node` - (Optional) The maximum number of pods per node in the node pools.
 * `os_disk_size_gb` - (Optional) The size of the OS disk in GB.
 * `os_disk_type` - (Optional, Enum:`"Managed" ,"Ephemeral"`) The type of the OS disk.

--- a/docs/resources/ocean_aks_np_virtual_node_group.md
+++ b/docs/resources/ocean_aks_np_virtual_node_group.md
@@ -157,6 +157,8 @@ resource "spotinst_ocean_aks_np_virtual_node_group" "example" {
     min_disk               = 1
     gpu_types              = ["nvidia-tesla-t4"]
   }
+
+  preferred_vm_sizes = ["Standard_D4s_v3", "Standard_D8s_v3"]
   
   // ----------------------------------------------------------------------------
   
@@ -254,6 +256,7 @@ The following arguments are supported:
     * `min_disk` - (Optional) Minimum number of data disks available.
     * `vm_types` - (Optional, Enum `"generalPurpose", "memoryOptimized", "computeOptimized", "highPerformanceCompute", "storageOptimized", "GPU"`) The filtered vm types will belong to one of the vm types from this list.
     * `gpu_types` - (Optional, Enum `"nvidia-tesla-v100", "amd-radeon-instinct-mi25", "nvidia-a10", "nvidia-tesla-a100", "nvidia-tesla-k80", "nvidia-tesla-m60", "nvidia-tesla-p100", "nvidia-tesla-p40", "nvidia-tesla-t4", "nvidia-tesla-h100"`) The filtered gpu types will belong to one of the gpu types from this list.
+* `preferred_vm_sizes` - (Optional) Preferred VM sizes for this virtual node group. Used when nodePoolProperties.encryptionAtHost is true to constrain launches to compatible sizes.
 * `scheduling`- (Optional) An object used to specify times when the virtual node group will turn off all its node pools. Once the shutdown time will be over, the virtual node group will return to its previous state.
   * `shutdown_hours` - (Optional) An object used to specify times that the nodes in the virtual node group will be stopped.
     * `is_enabled` - (Optional) Flag to enable or disable the shutdown hours mechanism. When `false`, the mechanism is deactivated, and the virtual node gorup remains in its current state.

--- a/docs/resources/ocean_right_sizing_rule.md
+++ b/docs/resources/ocean_right_sizing_rule.md
@@ -18,7 +18,10 @@ resource "spotinst_ocean_right_sizing_rule" "example" {
   rule_name = "test-rule"
   exclude_preliminary_recommendations= true
   restart_replicas="ALL_MANIFEST"
-
+  
+  cpu_percentile = 95
+  memory_percentile = 90
+  
   recommendation_application_hpa{
     allow_hpa_recommendations= true
   }
@@ -83,6 +86,8 @@ The following arguments are supported:
 * `rule_name` - (Required) The unique name of the rule.
 * `exclude_preliminary_recommendations` - (Optional) Exclude preliminary recommendations (recommendations based on less than 4 full days of data).
 * `restart_replicas` - (Optional) Valid values: "MORE_THAN_ONE_REPLICA" "ALL_MANIFEST" "NO_RESTART". Enable to sequentially restart pod batches according to recommendations, for all pods, only more than 1 replica, or not any pod.
+* `cpu_percentile` - (Optional) vCPU percentile for calculating recommendations.
+* `memory_percentile` - (Optional) Memory percentile for calculating recommendations.
 * `recommendation_application_boundaries` - (Optional) Determines the Ocean Rightsizing rule recommendation application boundaries.
    * `cpu_min` - (Optional) the minimal value of cpu in vCpu.
    * `cpu_max` - (Optional) the maximal value of cpu in vCpu.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.414.0
+	github.com/spotinst/spotinst-sdk-go v1.415.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/sethvargo/go-password v0.3.1
-	github.com/spotinst/spotinst-sdk-go v1.415.0
+	github.com/spotinst/spotinst-sdk-go v1.416.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )
 

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0
 github.com/skeema/knownhosts v1.3.0/go.mod h1:sPINvnADmT/qYH1kfv+ePMmOBTH6Tbl7b5LvTDjFK7M=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.414.0 h1:PFhtIQMthPjXfQfeGk5xoQ0DNXHZpb+nrL4fGuNcquw=
-github.com/spotinst/spotinst-sdk-go v1.414.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.415.0 h1:TvhbTyDOsxRrKcqndnS7nQ6IVkgZGJvFiGLj3m12HV8=
+github.com/spotinst/spotinst-sdk-go v1.415.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0
 github.com/skeema/knownhosts v1.3.0/go.mod h1:sPINvnADmT/qYH1kfv+ePMmOBTH6Tbl7b5LvTDjFK7M=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spotinst/spotinst-sdk-go v1.415.0 h1:TvhbTyDOsxRrKcqndnS7nQ6IVkgZGJvFiGLj3m12HV8=
-github.com/spotinst/spotinst-sdk-go v1.415.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/spotinst-sdk-go v1.416.0 h1:/SRmhGR8wNp8sXXAjZCUkK+jTgz1b3am2tp5sdWV2NU=
+github.com/spotinst/spotinst-sdk-go v1.416.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/spotinst/azure_v3/elastigroup_azure_launchspecification/consts.go
+++ b/spotinst/azure_v3/elastigroup_azure_launchspecification/consts.go
@@ -14,6 +14,7 @@ const (
 	ShutdownScript commons.FieldName = "shutdown_script"
 	UserData       commons.FieldName = "user_data"
 	VmNamePrefix   commons.FieldName = "vm_name_prefix"
+	LicenseType    commons.FieldName = "license_type"
 )
 
 const (

--- a/spotinst/azure_v3/elastigroup_azure_launchspecification/fields_spotinst_elastigroup_azure_launchspecification.go
+++ b/spotinst/azure_v3/elastigroup_azure_launchspecification/fields_spotinst_elastigroup_azure_launchspecification.go
@@ -586,6 +586,48 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		nil,
 	)
 
+	fieldsMap[LicenseType] = commons.NewGenericField(
+		commons.ElastigroupAzureLaunchSpecification,
+		LicenseType,
+		&schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			egWrapper := resourceObject.(*commons.ElastigroupAzureV3Wrapper)
+			elastigroup := egWrapper.GetElastigroup()
+			var value *string = nil
+			if elastigroup != nil && elastigroup.Compute != nil && elastigroup.Compute.LaunchSpecification != nil && elastigroup.Compute.LaunchSpecification.LicenseType != nil {
+				value = elastigroup.Compute.LaunchSpecification.LicenseType
+			}
+			if err := resourceData.Set(string(LicenseType), value); err != nil {
+				return fmt.Errorf(string(commons.FailureFieldReadPattern), string(LicenseType), err)
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			egWrapper := resourceObject.(*commons.ElastigroupAzureV3Wrapper)
+			elastigroup := egWrapper.GetElastigroup()
+			if v, ok := resourceData.Get(string(LicenseType)).(string); ok && v != "" {
+				licenseType := spotinst.String(v)
+				elastigroup.Compute.LaunchSpecification.SetLicenseType(licenseType)
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			egWrapper := resourceObject.(*commons.ElastigroupAzureV3Wrapper)
+			elastigroup := egWrapper.GetElastigroup()
+			var value *string = nil
+			if v, ok := resourceData.Get(string(LicenseType)).(string); ok && v != "" {
+				licenseType := spotinst.String(v)
+				value = licenseType
+			}
+			elastigroup.Compute.LaunchSpecification.SetLicenseType(value)
+			return nil
+		},
+		nil,
+	)
+
 	fieldsMap[Security] = commons.NewGenericField(
 		commons.ElastigroupAzureLaunchSpecification,
 		Security,

--- a/spotinst/ocean_aks_np_node_pool_properties/consts.go
+++ b/spotinst/ocean_aks_np_node_pool_properties/consts.go
@@ -16,3 +16,19 @@ const (
 	Sysctls            commons.FieldName = "sysctls"
 	VmMaxMapCount      commons.FieldName = "vm_max_map_count"
 )
+
+const (
+	LocalDnsProfile             commons.FieldName = "local_dns_profile"
+	Mode                        commons.FieldName = "mode"
+	VnetDNSOverrides            commons.FieldName = "vnet_dns_overrides"
+	KubeDNSOverrides            commons.FieldName = "kube_dns_overrides"
+	DNSZone                     commons.FieldName = "zone"
+	QueryLogging                commons.FieldName = "query_logging"
+	Protocol                    commons.FieldName = "protocol"
+	ForwardDestination          commons.FieldName = "forward_destination"
+	ForwardPolicy               commons.FieldName = "forward_policy"
+	MaxConcurrent               commons.FieldName = "max_concurrent"
+	CacheDurationInSeconds      commons.FieldName = "cache_duration_in_seconds"
+	ServeStaleDurationInSeconds commons.FieldName = "serve_stale_duration_in_seconds"
+	ServeStale                  commons.FieldName = "serve_stale"
+)

--- a/spotinst/ocean_aks_np_node_pool_properties/consts.go
+++ b/spotinst/ocean_aks_np_node_pool_properties/consts.go
@@ -15,6 +15,7 @@ const (
 	LinuxOSConfig      commons.FieldName = "linux_os_config"
 	Sysctls            commons.FieldName = "sysctls"
 	VmMaxMapCount      commons.FieldName = "vm_max_map_count"
+	EncryptionAtHost   commons.FieldName = "encryption_at_host"
 )
 
 const (

--- a/spotinst/ocean_aks_np_node_pool_properties/fields_spotinst_ocean_aks_np_node_pool_properties.go
+++ b/spotinst/ocean_aks_np_node_pool_properties/fields_spotinst_ocean_aks_np_node_pool_properties.go
@@ -453,6 +453,81 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		},
 		nil,
 	)
+
+	fieldsMap[LocalDnsProfile] = commons.NewGenericField(
+		commons.OceanAKSNPProperties,
+		LocalDnsProfile,
+		&schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					string(Mode): {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					string(VnetDNSOverrides): {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: dnsOverrideSettingsSchema(),
+						},
+					},
+					string(KubeDNSOverrides): {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: dnsOverrideSettingsSchema(),
+						},
+					},
+				},
+			},
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.AKSNPClusterWrapper)
+			cluster := clusterWrapper.GetNPCluster()
+			var value []interface{} = nil
+			if cluster.VirtualNodeGroupTemplate != nil && cluster.VirtualNodeGroupTemplate.NodePoolProperties != nil {
+				if cluster.VirtualNodeGroupTemplate.NodePoolProperties.LocalDnsProfile != nil {
+					value = flattenLocalDnsProfile(cluster.VirtualNodeGroupTemplate.NodePoolProperties.LocalDnsProfile)
+				}
+			}
+			if len(value) > 0 {
+				if err := resourceData.Set(string(LocalDnsProfile), value); err != nil {
+					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(LocalDnsProfile), err)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.AKSNPClusterWrapper)
+			cluster := clusterWrapper.GetNPCluster()
+			if value, ok := resourceData.GetOk(string(LocalDnsProfile)); ok {
+				if profile, err := expandLocalDnsProfile(value); err != nil {
+					return err
+				} else {
+					cluster.VirtualNodeGroupTemplate.NodePoolProperties.SetLocalDnsProfile(profile)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.AKSNPClusterWrapper)
+			cluster := clusterWrapper.GetNPCluster()
+			var profile *azure_np.LocalDnsProfile = nil
+			if v, ok := resourceData.GetOk(string(LocalDnsProfile)); ok {
+				if p, err := expandLocalDnsProfile(v); err != nil {
+					return err
+				} else {
+					profile = p
+				}
+			}
+			cluster.VirtualNodeGroupTemplate.NodePoolProperties.SetLocalDnsProfile(profile)
+			return nil
+		},
+		nil,
+	)
+
 }
 
 func flattenLinuxOSConfig(linuxConfig *azure_np.LinuxOSConfig) []interface{} {
@@ -467,6 +542,65 @@ func flattenLinuxOSConfig(linuxConfig *azure_np.LinuxOSConfig) []interface{} {
 		out = append(out, result)
 	}
 	return out
+}
+
+func flattenLocalDnsProfile(profile *azure_np.LocalDnsProfile) []interface{} {
+	var out []interface{}
+
+	if profile != nil {
+		result := make(map[string]interface{})
+
+		if profile.Mode != nil {
+			result[string(Mode)] = spotinst.StringValue(profile.Mode)
+		}
+		if profile.VnetDNSOverrides != nil {
+			result[string(VnetDNSOverrides)] = flattenDNSOverrides(profile.VnetDNSOverrides)
+		}
+		if profile.KubeDNSOverrides != nil {
+			result[string(KubeDNSOverrides)] = flattenDNSOverrides(profile.KubeDNSOverrides)
+		}
+		out = append(out, result)
+	}
+	return out
+}
+
+func flattenDNSOverrides(overrides map[string]*azure_np.DNSOverrideSettings) []interface{} {
+	result := make([]interface{}, 0, len(overrides))
+
+	for zone, dnsSettings := range overrides {
+		if dnsSettings == nil {
+			continue
+		}
+		item := make(map[string]interface{})
+		item[string(DNSZone)] = zone
+
+		if dnsSettings.QueryLogging != nil {
+			item[string(QueryLogging)] = spotinst.StringValue(dnsSettings.QueryLogging)
+		}
+		if dnsSettings.Protocol != nil {
+			item[string(Protocol)] = spotinst.StringValue(dnsSettings.Protocol)
+		}
+		if dnsSettings.ForwardDestination != nil {
+			item[string(ForwardDestination)] = spotinst.StringValue(dnsSettings.ForwardDestination)
+		}
+		if dnsSettings.ForwardPolicy != nil {
+			item[string(ForwardPolicy)] = spotinst.StringValue(dnsSettings.ForwardPolicy)
+		}
+		if dnsSettings.MaxConcurrent != nil {
+			item[string(MaxConcurrent)] = spotinst.IntValue(dnsSettings.MaxConcurrent)
+		}
+		if dnsSettings.CacheDurationInSeconds != nil {
+			item[string(CacheDurationInSeconds)] = spotinst.IntValue(dnsSettings.CacheDurationInSeconds)
+		}
+		if dnsSettings.ServeStaleDurationInSeconds != nil {
+			item[string(ServeStaleDurationInSeconds)] = spotinst.IntValue(dnsSettings.ServeStaleDurationInSeconds)
+		}
+		if dnsSettings.ServeStale != nil {
+			item[string(ServeStale)] = spotinst.StringValue(dnsSettings.ServeStale)
+		}
+		result = append(result, item)
+	}
+	return result
 }
 
 func flattenSysctls(sysctls *azure_np.Sysctls) []interface{} {
@@ -517,6 +651,99 @@ func expandLinuxOSConfig(data interface{}) (*azure_np.LinuxOSConfig, error) {
 	return nil, nil
 }
 
+func expandLocalDnsProfile(data interface{}) (*azure_np.LocalDnsProfile, error) {
+	list := data.([]interface{})
+	if len(list) == 0 || list[0] == nil {
+		return nil, nil
+	}
+	m := list[0].(map[string]interface{})
+	profile := &azure_np.LocalDnsProfile{}
+
+	if v, ok := m[string(Mode)].(string); ok && v != "" {
+		profile.SetMode(spotinst.String(v))
+	} else {
+		profile.SetMode(nil)
+	}
+
+	if v, ok := m[string(VnetDNSOverrides)]; ok {
+		overrides, err := expandDNSOverrides(v)
+		if err != nil {
+			return nil, err
+		}
+		if len(overrides) > 0 {
+			profile.SetVnetDNSOverrides(overrides)
+		} else {
+			profile.SetVnetDNSOverrides(nil)
+		}
+	} else {
+		profile.SetVnetDNSOverrides(nil)
+	}
+
+	if v, ok := m[string(KubeDNSOverrides)]; ok {
+		overrides, err := expandDNSOverrides(v)
+		if err != nil {
+			return nil, err
+		}
+		if len(overrides) > 0 {
+			profile.SetKubeDNSOverrides(overrides)
+		} else {
+			profile.SetKubeDNSOverrides(nil)
+		}
+	} else {
+		profile.SetKubeDNSOverrides(nil)
+	}
+
+	return profile, nil
+}
+
+func expandDNSOverrides(data interface{}) (map[string]*azure_np.DNSOverrideSettings, error) {
+	list := data.([]interface{})
+	result := make(map[string]*azure_np.DNSOverrideSettings, len(list))
+
+	for _, v := range list {
+		m, ok := v.(map[string]interface{})
+		if !ok || m == nil {
+			continue
+		}
+
+		zone, ok := m[string(DNSZone)].(string)
+		if !ok || zone == "" {
+			continue
+		}
+
+		settings := &azure_np.DNSOverrideSettings{}
+
+		if v, ok := m[string(QueryLogging)].(string); ok && v != "" {
+			settings.SetQueryLogging(spotinst.String(v))
+		}
+		if v, ok := m[string(Protocol)].(string); ok && v != "" {
+			settings.SetProtocol(spotinst.String(v))
+		}
+		if v, ok := m[string(ForwardDestination)].(string); ok && v != "" {
+			settings.SetForwardDestination(spotinst.String(v))
+		}
+		if v, ok := m[string(ForwardPolicy)].(string); ok && v != "" {
+			settings.SetForwardPolicy(spotinst.String(v))
+		}
+		if v, ok := m[string(MaxConcurrent)].(int); ok && v > 0 {
+			settings.SetMaxConcurrent(spotinst.Int(v))
+		}
+		if v, ok := m[string(CacheDurationInSeconds)].(int); ok && v > 0 {
+			settings.SetCacheDurationInSeconds(spotinst.Int(v))
+		}
+		if v, ok := m[string(ServeStaleDurationInSeconds)].(int); ok && v > 0 {
+			settings.SetServeStaleDurationInSeconds(spotinst.Int(v))
+		}
+		if v, ok := m[string(ServeStale)].(string); ok && v != "" {
+			settings.SetServeStale(spotinst.String(v))
+		}
+
+		result[zone] = settings
+	}
+
+	return result, nil
+}
+
 func expandSysctls(data interface{}) (*azure_np.Sysctls, error) {
 	if list := data.([]interface{}); len(list) > 0 {
 		sysctls := &azure_np.Sysctls{}
@@ -529,4 +756,45 @@ func expandSysctls(data interface{}) (*azure_np.Sysctls, error) {
 		return sysctls, nil
 	}
 	return nil, nil
+}
+
+func dnsOverrideSettingsSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		string(DNSZone): {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		string(QueryLogging): {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		string(Protocol): {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		string(ForwardDestination): {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		string(ForwardPolicy): {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		string(MaxConcurrent): {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		string(CacheDurationInSeconds): {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		string(ServeStaleDurationInSeconds): {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		string(ServeStale): {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	}
 }

--- a/spotinst/ocean_aks_np_node_pool_properties/fields_spotinst_ocean_aks_np_node_pool_properties.go
+++ b/spotinst/ocean_aks_np_node_pool_properties/fields_spotinst_ocean_aks_np_node_pool_properties.go
@@ -103,6 +103,50 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		nil,
 	)
 
+	fieldsMap[EncryptionAtHost] = commons.NewGenericField(
+		commons.OceanAKSNPProperties,
+		EncryptionAtHost,
+		&schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.AKSNPClusterWrapper)
+			cluster := clusterWrapper.GetNPCluster()
+			var value *bool = nil
+			if cluster.VirtualNodeGroupTemplate != nil && cluster.VirtualNodeGroupTemplate.NodePoolProperties != nil &&
+				cluster.VirtualNodeGroupTemplate.NodePoolProperties.EncryptionAtHost != nil {
+				value = cluster.VirtualNodeGroupTemplate.NodePoolProperties.EncryptionAtHost
+			}
+			if value != nil {
+				if err := resourceData.Set(string(EncryptionAtHost), spotinst.BoolValue(value)); err != nil {
+					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(EncryptionAtHost), err)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.AKSNPClusterWrapper)
+			cluster := clusterWrapper.GetNPCluster()
+			if v, ok := resourceData.GetOkExists(string(EncryptionAtHost)); ok && v != nil {
+				cluster.VirtualNodeGroupTemplate.NodePoolProperties.SetEncryptionAtHost(spotinst.Bool(v.(bool)))
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.AKSNPClusterWrapper)
+			cluster := clusterWrapper.GetNPCluster()
+			var encryptionAtHost *bool = nil
+			if v, ok := resourceData.GetOkExists(string(EncryptionAtHost)); ok && v != nil {
+				encryptionAtHost = spotinst.Bool(v.(bool))
+			}
+			cluster.VirtualNodeGroupTemplate.NodePoolProperties.SetEncryptionAtHost(encryptionAtHost)
+			return nil
+		},
+		nil,
+	)
+
 	fieldsMap[OsDiskSizeGB] = commons.NewGenericField(
 		commons.OceanAKSNPProperties,
 		OsDiskSizeGB,

--- a/spotinst/ocean_aks_np_node_pool_properties/fields_spotinst_ocean_aks_np_node_pool_properties.go
+++ b/spotinst/ocean_aks_np_node_pool_properties/fields_spotinst_ocean_aks_np_node_pool_properties.go
@@ -2,6 +2,7 @@ package ocean_aks_np_node_pool_properties
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/spotinst/spotinst-sdk-go/service/ocean/providers/azure_np"
 
@@ -609,38 +610,45 @@ func flattenLocalDnsProfile(profile *azure_np.LocalDnsProfile) []interface{} {
 }
 
 func flattenDNSOverrides(overrides map[string]*azure_np.DNSOverrideSettings) []interface{} {
+	zones := make([]string, 0, len(overrides))
+	for zone := range overrides {
+		zones = append(zones, zone)
+	}
+	sort.Strings(zones)
+
 	result := make([]interface{}, 0, len(overrides))
 
-	for zone, dnsSettings := range overrides {
-		if dnsSettings == nil {
+	for _, zone := range zones {
+		settings := overrides[zone]
+		if settings == nil {
 			continue
 		}
 		item := make(map[string]interface{})
 		item[string(DNSZone)] = zone
 
-		if dnsSettings.QueryLogging != nil {
-			item[string(QueryLogging)] = spotinst.StringValue(dnsSettings.QueryLogging)
+		if settings.QueryLogging != nil {
+			item[string(QueryLogging)] = spotinst.StringValue(settings.QueryLogging)
 		}
-		if dnsSettings.Protocol != nil {
-			item[string(Protocol)] = spotinst.StringValue(dnsSettings.Protocol)
+		if settings.Protocol != nil {
+			item[string(Protocol)] = spotinst.StringValue(settings.Protocol)
 		}
-		if dnsSettings.ForwardDestination != nil {
-			item[string(ForwardDestination)] = spotinst.StringValue(dnsSettings.ForwardDestination)
+		if settings.ForwardDestination != nil {
+			item[string(ForwardDestination)] = spotinst.StringValue(settings.ForwardDestination)
 		}
-		if dnsSettings.ForwardPolicy != nil {
-			item[string(ForwardPolicy)] = spotinst.StringValue(dnsSettings.ForwardPolicy)
+		if settings.ForwardPolicy != nil {
+			item[string(ForwardPolicy)] = spotinst.StringValue(settings.ForwardPolicy)
 		}
-		if dnsSettings.MaxConcurrent != nil {
-			item[string(MaxConcurrent)] = spotinst.IntValue(dnsSettings.MaxConcurrent)
+		if settings.MaxConcurrent != nil {
+			item[string(MaxConcurrent)] = spotinst.IntValue(settings.MaxConcurrent)
 		}
-		if dnsSettings.CacheDurationInSeconds != nil {
-			item[string(CacheDurationInSeconds)] = spotinst.IntValue(dnsSettings.CacheDurationInSeconds)
+		if settings.CacheDurationInSeconds != nil {
+			item[string(CacheDurationInSeconds)] = spotinst.IntValue(settings.CacheDurationInSeconds)
 		}
-		if dnsSettings.ServeStaleDurationInSeconds != nil {
-			item[string(ServeStaleDurationInSeconds)] = spotinst.IntValue(dnsSettings.ServeStaleDurationInSeconds)
+		if settings.ServeStaleDurationInSeconds != nil {
+			item[string(ServeStaleDurationInSeconds)] = spotinst.IntValue(settings.ServeStaleDurationInSeconds)
 		}
-		if dnsSettings.ServeStale != nil {
-			item[string(ServeStale)] = spotinst.StringValue(dnsSettings.ServeStale)
+		if settings.ServeStale != nil {
+			item[string(ServeStale)] = spotinst.StringValue(settings.ServeStale)
 		}
 		result = append(result, item)
 	}

--- a/spotinst/ocean_aks_np_virtual_node_group_node_pool_properties/consts.go
+++ b/spotinst/ocean_aks_np_virtual_node_group_node_pool_properties/consts.go
@@ -16,3 +16,19 @@ const (
 	Sysctls            commons.FieldName = "sysctls"
 	VmMaxMapCount      commons.FieldName = "vm_max_map_count"
 )
+
+const (
+	LocalDnsProfile             commons.FieldName = "local_dns_profile"
+	Mode                        commons.FieldName = "mode"
+	VnetDNSOverrides            commons.FieldName = "vnet_dns_overrides"
+	KubeDNSOverrides            commons.FieldName = "kube_dns_overrides"
+	DNSZone                     commons.FieldName = "zone"
+	QueryLogging                commons.FieldName = "query_logging"
+	Protocol                    commons.FieldName = "protocol"
+	ForwardDestination          commons.FieldName = "forward_destination"
+	ForwardPolicy               commons.FieldName = "forward_policy"
+	MaxConcurrent               commons.FieldName = "max_concurrent"
+	CacheDurationInSeconds      commons.FieldName = "cache_duration_in_seconds"
+	ServeStaleDurationInSeconds commons.FieldName = "serve_stale_duration_in_seconds"
+	ServeStale                  commons.FieldName = "serve_stale"
+)

--- a/spotinst/ocean_aks_np_virtual_node_group_node_pool_properties/consts.go
+++ b/spotinst/ocean_aks_np_virtual_node_group_node_pool_properties/consts.go
@@ -15,6 +15,7 @@ const (
 	LinuxOSConfig      commons.FieldName = "linux_os_config"
 	Sysctls            commons.FieldName = "sysctls"
 	VmMaxMapCount      commons.FieldName = "vm_max_map_count"
+	EncryptionAtHost   commons.FieldName = "encryption_at_host"
 )
 
 const (

--- a/spotinst/ocean_aks_np_virtual_node_group_node_pool_properties/fields_spotinst_ocean_aks_np_virtual_node_group_node_pool_properties.go
+++ b/spotinst/ocean_aks_np_virtual_node_group_node_pool_properties/fields_spotinst_ocean_aks_np_virtual_node_group_node_pool_properties.go
@@ -451,6 +451,78 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		},
 		nil,
 	)
+
+	fieldsMap[LocalDnsProfile] = commons.NewGenericField(
+		commons.OceanAKSNPVirtualNodeGroupNodePoolProperties,
+		LocalDnsProfile,
+		&schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					string(Mode): {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					string(VnetDNSOverrides): {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: dnsOverrideSettingsSchema(),
+						},
+					},
+					string(KubeDNSOverrides): {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: dnsOverrideSettingsSchema(),
+						},
+					},
+				},
+			},
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			vngWrapper := resourceObject.(*commons.VirtualNodeGroupAKSNPWrapper)
+			virtualNodeGroup := vngWrapper.GetVirtualNodeGroup()
+			var value []interface{} = nil
+			if virtualNodeGroup.NodePoolProperties != nil && virtualNodeGroup.NodePoolProperties.LocalDnsProfile != nil {
+				value = flattenLocalDnsProfile(virtualNodeGroup.NodePoolProperties.LocalDnsProfile)
+			}
+			if len(value) > 0 {
+				if err := resourceData.Set(string(LocalDnsProfile), value); err != nil {
+					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(LocalDnsProfile), err)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			vngWrapper := resourceObject.(*commons.VirtualNodeGroupAKSNPWrapper)
+			virtualNodeGroup := vngWrapper.GetVirtualNodeGroup()
+			if value, ok := resourceData.GetOk(string(LocalDnsProfile)); ok {
+				if profile, err := expandLocalDnsProfile(value); err != nil {
+					return err
+				} else {
+					virtualNodeGroup.NodePoolProperties.SetLocalDnsProfile(profile)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			vngWrapper := resourceObject.(*commons.VirtualNodeGroupAKSNPWrapper)
+			virtualNodeGroup := vngWrapper.GetVirtualNodeGroup()
+			var profile *azure_np.LocalDnsProfile = nil
+			if v, ok := resourceData.GetOk(string(LocalDnsProfile)); ok {
+				if p, err := expandLocalDnsProfile(v); err != nil {
+					return err
+				} else {
+					profile = p
+				}
+			}
+			virtualNodeGroup.NodePoolProperties.SetLocalDnsProfile(profile)
+			return nil
+		},
+		nil,
+	)
 }
 
 func flattenLinuxOSConfig(linuxConfig *azure_np.LinuxOSConfig) []interface{} {
@@ -465,6 +537,65 @@ func flattenLinuxOSConfig(linuxConfig *azure_np.LinuxOSConfig) []interface{} {
 		out = append(out, result)
 	}
 	return out
+}
+
+func flattenLocalDnsProfile(profile *azure_np.LocalDnsProfile) []interface{} {
+	var out []interface{}
+
+	if profile != nil {
+		result := make(map[string]interface{})
+
+		if profile.Mode != nil {
+			result[string(Mode)] = spotinst.StringValue(profile.Mode)
+		}
+		if profile.VnetDNSOverrides != nil {
+			result[string(VnetDNSOverrides)] = flattenDNSOverrides(profile.VnetDNSOverrides)
+		}
+		if profile.KubeDNSOverrides != nil {
+			result[string(KubeDNSOverrides)] = flattenDNSOverrides(profile.KubeDNSOverrides)
+		}
+		out = append(out, result)
+	}
+	return out
+}
+
+func flattenDNSOverrides(overrides map[string]*azure_np.DNSOverrideSettings) []interface{} {
+	result := make([]interface{}, 0, len(overrides))
+
+	for zone, settings := range overrides {
+		if settings == nil {
+			continue
+		}
+		item := make(map[string]interface{})
+		item[string(DNSZone)] = zone
+
+		if settings.QueryLogging != nil {
+			item[string(QueryLogging)] = spotinst.StringValue(settings.QueryLogging)
+		}
+		if settings.Protocol != nil {
+			item[string(Protocol)] = spotinst.StringValue(settings.Protocol)
+		}
+		if settings.ForwardDestination != nil {
+			item[string(ForwardDestination)] = spotinst.StringValue(settings.ForwardDestination)
+		}
+		if settings.ForwardPolicy != nil {
+			item[string(ForwardPolicy)] = spotinst.StringValue(settings.ForwardPolicy)
+		}
+		if settings.MaxConcurrent != nil {
+			item[string(MaxConcurrent)] = spotinst.IntValue(settings.MaxConcurrent)
+		}
+		if settings.CacheDurationInSeconds != nil {
+			item[string(CacheDurationInSeconds)] = spotinst.IntValue(settings.CacheDurationInSeconds)
+		}
+		if settings.ServeStaleDurationInSeconds != nil {
+			item[string(ServeStaleDurationInSeconds)] = spotinst.IntValue(settings.ServeStaleDurationInSeconds)
+		}
+		if settings.ServeStale != nil {
+			item[string(ServeStale)] = spotinst.StringValue(settings.ServeStale)
+		}
+		result = append(result, item)
+	}
+	return result
 }
 
 func flattenSysctls(sysctls *azure_np.Sysctls) []interface{} {
@@ -515,6 +646,99 @@ func expandLinuxOSConfig(data interface{}) (*azure_np.LinuxOSConfig, error) {
 	return nil, nil
 }
 
+func expandLocalDnsProfile(data interface{}) (*azure_np.LocalDnsProfile, error) {
+	list := data.([]interface{})
+	if len(list) == 0 || list[0] == nil {
+		return nil, nil
+	}
+	m := list[0].(map[string]interface{})
+	profile := &azure_np.LocalDnsProfile{}
+
+	if v, ok := m[string(Mode)].(string); ok && v != "" {
+		profile.SetMode(spotinst.String(v))
+	} else {
+		profile.SetMode(nil)
+	}
+
+	if v, ok := m[string(VnetDNSOverrides)]; ok {
+		overrides, err := expandDNSOverrides(v)
+		if err != nil {
+			return nil, err
+		}
+		if len(overrides) > 0 {
+			profile.SetVnetDNSOverrides(overrides)
+		} else {
+			profile.SetVnetDNSOverrides(nil)
+		}
+	} else {
+		profile.SetVnetDNSOverrides(nil)
+	}
+
+	if v, ok := m[string(KubeDNSOverrides)]; ok {
+		overrides, err := expandDNSOverrides(v)
+		if err != nil {
+			return nil, err
+		}
+		if len(overrides) > 0 {
+			profile.SetKubeDNSOverrides(overrides)
+		} else {
+			profile.SetKubeDNSOverrides(nil)
+		}
+	} else {
+		profile.SetKubeDNSOverrides(nil)
+	}
+
+	return profile, nil
+}
+
+func expandDNSOverrides(data interface{}) (map[string]*azure_np.DNSOverrideSettings, error) {
+	list := data.([]interface{})
+	result := make(map[string]*azure_np.DNSOverrideSettings, len(list))
+
+	for _, v := range list {
+		m, ok := v.(map[string]interface{})
+		if !ok || m == nil {
+			continue
+		}
+
+		zone, ok := m[string(DNSZone)].(string)
+		if !ok || zone == "" {
+			continue
+		}
+
+		settings := &azure_np.DNSOverrideSettings{}
+
+		if v, ok := m[string(QueryLogging)].(string); ok && v != "" {
+			settings.SetQueryLogging(spotinst.String(v))
+		}
+		if v, ok := m[string(Protocol)].(string); ok && v != "" {
+			settings.SetProtocol(spotinst.String(v))
+		}
+		if v, ok := m[string(ForwardDestination)].(string); ok && v != "" {
+			settings.SetForwardDestination(spotinst.String(v))
+		}
+		if v, ok := m[string(ForwardPolicy)].(string); ok && v != "" {
+			settings.SetForwardPolicy(spotinst.String(v))
+		}
+		if v, ok := m[string(MaxConcurrent)].(int); ok && v > 0 {
+			settings.SetMaxConcurrent(spotinst.Int(v))
+		}
+		if v, ok := m[string(CacheDurationInSeconds)].(int); ok && v > 0 {
+			settings.SetCacheDurationInSeconds(spotinst.Int(v))
+		}
+		if v, ok := m[string(ServeStaleDurationInSeconds)].(int); ok && v > 0 {
+			settings.SetServeStaleDurationInSeconds(spotinst.Int(v))
+		}
+		if v, ok := m[string(ServeStale)].(string); ok && v != "" {
+			settings.SetServeStale(spotinst.String(v))
+		}
+
+		result[zone] = settings
+	}
+
+	return result, nil
+}
+
 func expandSysctls(data interface{}) (*azure_np.Sysctls, error) {
 	if list := data.([]interface{}); len(list) > 0 {
 		sysctls := &azure_np.Sysctls{}
@@ -527,4 +751,45 @@ func expandSysctls(data interface{}) (*azure_np.Sysctls, error) {
 		return sysctls, nil
 	}
 	return nil, nil
+}
+
+func dnsOverrideSettingsSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		string(DNSZone): {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		string(QueryLogging): {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		string(Protocol): {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		string(ForwardDestination): {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		string(ForwardPolicy): {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		string(MaxConcurrent): {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		string(CacheDurationInSeconds): {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		string(ServeStaleDurationInSeconds): {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		string(ServeStale): {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	}
 }

--- a/spotinst/ocean_aks_np_virtual_node_group_node_pool_properties/fields_spotinst_ocean_aks_np_virtual_node_group_node_pool_properties.go
+++ b/spotinst/ocean_aks_np_virtual_node_group_node_pool_properties/fields_spotinst_ocean_aks_np_virtual_node_group_node_pool_properties.go
@@ -103,6 +103,49 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		nil,
 	)
 
+	fieldsMap[EncryptionAtHost] = commons.NewGenericField(
+		commons.OceanAKSNPVirtualNodeGroupNodePoolProperties,
+		EncryptionAtHost,
+		&schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			vngWrapper := resourceObject.(*commons.VirtualNodeGroupAKSNPWrapper)
+			virtualNodeGroup := vngWrapper.GetVirtualNodeGroup()
+			var value *bool = nil
+			if virtualNodeGroup.NodePoolProperties != nil && virtualNodeGroup.NodePoolProperties.EncryptionAtHost != nil {
+				value = virtualNodeGroup.NodePoolProperties.EncryptionAtHost
+			}
+			if value != nil {
+				if err := resourceData.Set(string(EncryptionAtHost), spotinst.BoolValue(value)); err != nil {
+					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(EncryptionAtHost), err)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			vngWrapper := resourceObject.(*commons.VirtualNodeGroupAKSNPWrapper)
+			virtualNodeGroup := vngWrapper.GetVirtualNodeGroup()
+			if v, ok := resourceData.GetOkExists(string(EncryptionAtHost)); ok && v != nil {
+				virtualNodeGroup.NodePoolProperties.SetEncryptionAtHost(spotinst.Bool(v.(bool)))
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			vngWrapper := resourceObject.(*commons.VirtualNodeGroupAKSNPWrapper)
+			virtualNodeGroup := vngWrapper.GetVirtualNodeGroup()
+			var encryptionAtHost *bool = nil
+			if v, ok := resourceData.GetOkExists(string(EncryptionAtHost)); ok && v != nil {
+				encryptionAtHost = spotinst.Bool(v.(bool))
+			}
+			virtualNodeGroup.NodePoolProperties.SetEncryptionAtHost(encryptionAtHost)
+			return nil
+		},
+		nil,
+	)
+
 	fieldsMap[OsDiskSizeGB] = commons.NewGenericField(
 		commons.OceanAKSNPVirtualNodeGroupNodePoolProperties,
 		OsDiskSizeGB,

--- a/spotinst/ocean_aks_np_virtual_node_group_node_pool_properties/fields_spotinst_ocean_aks_np_virtual_node_group_node_pool_properties.go
+++ b/spotinst/ocean_aks_np_virtual_node_group_node_pool_properties/fields_spotinst_ocean_aks_np_virtual_node_group_node_pool_properties.go
@@ -2,6 +2,7 @@ package ocean_aks_np_virtual_node_group_node_pool_properties
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/spotinst/spotinst-sdk-go/service/ocean/providers/azure_np"
 
@@ -603,9 +604,16 @@ func flattenLocalDnsProfile(profile *azure_np.LocalDnsProfile) []interface{} {
 }
 
 func flattenDNSOverrides(overrides map[string]*azure_np.DNSOverrideSettings) []interface{} {
+	zones := make([]string, 0, len(overrides))
+	for zone := range overrides {
+		zones = append(zones, zone)
+	}
+	sort.Strings(zones)
+
 	result := make([]interface{}, 0, len(overrides))
 
-	for zone, settings := range overrides {
+	for _, zone := range zones {
+		settings := overrides[zone]
 		if settings == nil {
 			continue
 		}
@@ -640,7 +648,6 @@ func flattenDNSOverrides(overrides map[string]*azure_np.DNSOverrideSettings) []i
 	}
 	return result
 }
-
 func flattenSysctls(sysctls *azure_np.Sysctls) []interface{} {
 	var out []interface{}
 

--- a/spotinst/ocean_aks_np_virtual_node_group_node_pool_properties/fields_spotinst_ocean_aks_np_virtual_node_group_node_pool_properties.go
+++ b/spotinst/ocean_aks_np_virtual_node_group_node_pool_properties/fields_spotinst_ocean_aks_np_virtual_node_group_node_pool_properties.go
@@ -648,6 +648,7 @@ func flattenDNSOverrides(overrides map[string]*azure_np.DNSOverrideSettings) []i
 	}
 	return result
 }
+
 func flattenSysctls(sysctls *azure_np.Sysctls) []interface{} {
 	var out []interface{}
 

--- a/spotinst/ocean_aks_np_virtual_node_group_vm_sizes/consts.go
+++ b/spotinst/ocean_aks_np_virtual_node_group_vm_sizes/consts.go
@@ -19,4 +19,5 @@ const (
 	MinDisk               commons.FieldName = "min_disk"
 	VmTypes               commons.FieldName = "vm_types"
 	GpuTypes              commons.FieldName = "gpu_types"
+	PreferredVmSizes      commons.FieldName = "preferred_vm_sizes"
 )

--- a/spotinst/ocean_aks_np_virtual_node_group_vm_sizes/fields_spotinst_ocean_aks_np_virtual_node_group_vm_sizes.go
+++ b/spotinst/ocean_aks_np_virtual_node_group_vm_sizes/fields_spotinst_ocean_aks_np_virtual_node_group_vm_sizes.go
@@ -159,6 +159,59 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		},
 		nil,
 	)
+
+	fieldsMap[PreferredVmSizes] = commons.NewGenericField(
+		commons.OceanAKSNPVirtualNodeGroupVmSizes,
+		PreferredVmSizes,
+		&schema.Schema{
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			vngWrapper := resourceObject.(*commons.VirtualNodeGroupAKSNPWrapper)
+			virtualNodeGroup := vngWrapper.GetVirtualNodeGroup()
+			var value []string = nil
+			if virtualNodeGroup != nil && virtualNodeGroup.VmSizes != nil &&
+				virtualNodeGroup.VmSizes.PreferredVmSizes != nil {
+				value = virtualNodeGroup.VmSizes.PreferredVmSizes
+			}
+			if err := resourceData.Set(string(PreferredVmSizes), value); err != nil {
+				return fmt.Errorf(commons.FailureFieldReadPattern, string(PreferredVmSizes), err)
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			vngWrapper := resourceObject.(*commons.VirtualNodeGroupAKSNPWrapper)
+			virtualNodeGroup := vngWrapper.GetVirtualNodeGroup()
+			if v, ok := resourceData.GetOk(string(PreferredVmSizes)); ok {
+				if preferredVmSizes, err := expandPreferredVmSizes(v); err != nil {
+					return err
+				} else {
+					virtualNodeGroup.VmSizes.SetPreferredVmSizes(preferredVmSizes)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			vngWrapper := resourceObject.(*commons.VirtualNodeGroupAKSNPWrapper)
+			virtualNodeGroup := vngWrapper.GetVirtualNodeGroup()
+			var value []string = nil
+			if v, ok := resourceData.GetOk(string(PreferredVmSizes)); ok {
+				if preferredVmSizes, err := expandPreferredVmSizes(v); err != nil {
+					return err
+				} else {
+					value = preferredVmSizes
+				}
+			}
+			if virtualNodeGroup.VmSizes == nil {
+				virtualNodeGroup.VmSizes = &azure_np.VmSizes{}
+			}
+			virtualNodeGroup.VmSizes.SetPreferredVmSizes(value)
+			return nil
+		},
+		nil,
+	)
 }
 
 func expandFilters(data interface{}, nullify bool) (*azure_np.Filters, error) {
@@ -325,6 +378,17 @@ func expandVmSizesFiltersList(data interface{}) ([]string, error) {
 	for _, v := range list {
 		if vmSizeList, ok := v.(string); ok && vmSizeList != "" {
 			result = append(result, vmSizeList)
+		}
+	}
+	return result, nil
+}
+
+func expandPreferredVmSizes(data interface{}) ([]string, error) {
+	list := data.(*schema.Set).List()
+	result := make([]string, 0, len(list))
+	for _, v := range list {
+		if vmSize, ok := v.(string); ok && vmSize != "" {
+			result = append(result, vmSize)
 		}
 	}
 	return result, nil

--- a/spotinst/ocean_aks_np_vm_sizes/consts.go
+++ b/spotinst/ocean_aks_np_vm_sizes/consts.go
@@ -19,4 +19,5 @@ const (
 	MinDisk               commons.FieldName = "min_disk"
 	VmTypes               commons.FieldName = "vm_types"
 	GpuTypes              commons.FieldName = "gpu_types"
+	PreferredVmSizes      commons.FieldName = "preferred_vm_sizes"
 )

--- a/spotinst/ocean_aks_np_vm_sizes/fields_spotinst_ocean_aks_np_vm_sizes.go
+++ b/spotinst/ocean_aks_np_vm_sizes/fields_spotinst_ocean_aks_np_vm_sizes.go
@@ -159,6 +159,58 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		},
 		nil,
 	)
+
+	fieldsMap[PreferredVmSizes] = commons.NewGenericField(
+		commons.OceanAKSNPVmSizes,
+		PreferredVmSizes,
+		&schema.Schema{
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.AKSNPClusterWrapper)
+			cluster := clusterWrapper.GetNPCluster()
+			var value []string = nil
+			if cluster != nil && cluster.VirtualNodeGroupTemplate != nil && cluster.VirtualNodeGroupTemplate.VmSizes != nil && cluster.VirtualNodeGroupTemplate.VmSizes.PreferredVmSizes != nil {
+				value = cluster.VirtualNodeGroupTemplate.VmSizes.PreferredVmSizes
+			}
+			if err := resourceData.Set(string(PreferredVmSizes), value); err != nil {
+				return fmt.Errorf(commons.FailureFieldReadPattern, string(PreferredVmSizes), err)
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.AKSNPClusterWrapper)
+			cluster := clusterWrapper.GetNPCluster()
+			if v, ok := resourceData.GetOk(string(PreferredVmSizes)); ok {
+				if preferredVmSizes, err := expandPreferredVmSizes(v); err != nil {
+					return err
+				} else {
+					cluster.VirtualNodeGroupTemplate.VmSizes.SetPreferredVmSizes(preferredVmSizes)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			clusterWrapper := resourceObject.(*commons.AKSNPClusterWrapper)
+			cluster := clusterWrapper.GetNPCluster()
+			var value []string = nil
+			if v, ok := resourceData.GetOk(string(PreferredVmSizes)); ok {
+				if preferredVmSizes, err := expandPreferredVmSizes(v); err != nil {
+					return err
+				} else {
+					value = preferredVmSizes
+				}
+			}
+			if cluster.VirtualNodeGroupTemplate.VmSizes == nil {
+				cluster.VirtualNodeGroupTemplate.VmSizes = &azure_np.VmSizes{}
+			}
+			cluster.VirtualNodeGroupTemplate.VmSizes.SetPreferredVmSizes(value)
+			return nil
+		},
+		nil,
+	)
 }
 
 func expandFilters(data interface{}, nullify bool) (*azure_np.Filters, error) {
@@ -325,6 +377,17 @@ func expandVmSizesFiltersList(data interface{}) ([]string, error) {
 	for _, v := range list {
 		if vmSizeList, ok := v.(string); ok && vmSizeList != "" {
 			result = append(result, vmSizeList)
+		}
+	}
+	return result, nil
+}
+
+func expandPreferredVmSizes(data interface{}) ([]string, error) {
+	list := data.(*schema.Set).List()
+	result := make([]string, 0, len(list))
+	for _, v := range list {
+		if vmSize, ok := v.(string); ok && vmSize != "" {
+			result = append(result, vmSize)
 		}
 	}
 	return result, nil

--- a/spotinst/ocean_right_sizing_rule/consts.go
+++ b/spotinst/ocean_right_sizing_rule/consts.go
@@ -3,9 +3,11 @@ package ocean_right_sizing_rule
 import "github.com/spotinst/terraform-provider-spotinst/spotinst/commons"
 
 const (
-	OceanId      commons.FieldName = "ocean_id"
-	RuleName     commons.FieldName = "rule_name"
-	DownsideOnly commons.FieldName = "downside_only"
+	OceanId          commons.FieldName = "ocean_id"
+	RuleName         commons.FieldName = "rule_name"
+	DownsideOnly     commons.FieldName = "downside_only"
+	CpuPercentile    commons.FieldName = "cpu_percentile"
+	MemoryPercentile commons.FieldName = "memory_percentile"
 
 	RecommendationApplicationIntervals  commons.FieldName = "recommendation_application_intervals"
 	RepetitionBasis                     commons.FieldName = "repetition_basis"

--- a/spotinst/ocean_right_sizing_rule/fields_spotinst_ocean_right_sizing_rule.go
+++ b/spotinst/ocean_right_sizing_rule/fields_spotinst_ocean_right_sizing_rule.go
@@ -793,6 +793,90 @@ func Setup(fieldsMap map[commons.FieldName]*commons.GenericField) {
 		nil,
 	)
 
+	fieldsMap[CpuPercentile] = commons.NewGenericField(
+		commons.OceanRightSizingRule,
+		CpuPercentile,
+		&schema.Schema{
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			rightSizingRuleWrapper := resourceObject.(*commons.RightSizingRuleWrapper)
+			rightSizingRule := rightSizingRuleWrapper.GetOceanRightSizingRule()
+			var value *int = nil
+			if rightSizingRule.CpuPercentile != nil {
+				value = rightSizingRule.CpuPercentile
+			}
+			if value != nil {
+				if err := resourceData.Set(string(CpuPercentile), spotinst.IntValue(value)); err != nil {
+					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(CpuPercentile), err)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			rightSizingRuleWrapper := resourceObject.(*commons.RightSizingRuleWrapper)
+			rightSizingRule := rightSizingRuleWrapper.GetOceanRightSizingRule()
+			if v, ok := resourceData.GetOkExists(string(CpuPercentile)); ok && v != nil {
+				rightSizingRule.SetCpuPercentile(spotinst.Int(v.(int)))
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			rightSizingRuleWrapper := resourceObject.(*commons.RightSizingRuleWrapper)
+			rightSizingRule := rightSizingRuleWrapper.GetOceanRightSizingRule()
+			var cpuPercentile *int = nil
+			if v, ok := resourceData.GetOkExists(string(CpuPercentile)); ok && v != nil {
+				cpuPercentile = spotinst.Int(v.(int))
+			}
+			rightSizingRule.SetCpuPercentile(cpuPercentile)
+			return nil
+		},
+		nil,
+	)
+
+	fieldsMap[MemoryPercentile] = commons.NewGenericField(
+		commons.OceanRightSizingRule,
+		MemoryPercentile,
+		&schema.Schema{
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			rightSizingRuleWrapper := resourceObject.(*commons.RightSizingRuleWrapper)
+			rightSizingRule := rightSizingRuleWrapper.GetOceanRightSizingRule()
+			var value *int = nil
+			if rightSizingRule.MemoryPercentile != nil {
+				value = rightSizingRule.MemoryPercentile
+			}
+			if value != nil {
+				if err := resourceData.Set(string(MemoryPercentile), spotinst.IntValue(value)); err != nil {
+					return fmt.Errorf(string(commons.FailureFieldReadPattern), string(MemoryPercentile), err)
+				}
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			rightSizingRuleWrapper := resourceObject.(*commons.RightSizingRuleWrapper)
+			rightSizingRule := rightSizingRuleWrapper.GetOceanRightSizingRule()
+			if v, ok := resourceData.GetOkExists(string(MemoryPercentile)); ok && v != nil {
+				rightSizingRule.SetMemoryPercentile(spotinst.Int(v.(int)))
+			}
+			return nil
+		},
+		func(resourceObject interface{}, resourceData *schema.ResourceData, meta interface{}) error {
+			rightSizingRuleWrapper := resourceObject.(*commons.RightSizingRuleWrapper)
+			rightSizingRule := rightSizingRuleWrapper.GetOceanRightSizingRule()
+			var memoryPercentile *int = nil
+			if v, ok := resourceData.GetOkExists(string(MemoryPercentile)); ok && v != nil {
+				memoryPercentile = spotinst.Int(v.(int))
+			}
+			rightSizingRule.SetMemoryPercentile(memoryPercentile)
+			return nil
+		},
+		nil,
+	)
+
 }
 
 func flattenRecommendationApplicationIntervals(recommendationApplicationIntervals []*right_sizing.RecommendationApplicationIntervals) []interface{} {

--- a/spotinst/resource_spotinst_elastigroup_azure_v3_test.go
+++ b/spotinst/resource_spotinst_elastigroup_azure_v3_test.go
@@ -206,6 +206,7 @@ func TestAccSpotinstElastigroupAzureV3_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "desired_capacity", "0"),
 					resource.TestCheckResourceAttr(resourceName, "os", "Linux"),
 					resource.TestCheckResourceAttr(resourceName, "custom_data", "IyEvY=IyEvYmluL2Jhc2gKZWNobyAidGVzdCI="),
+					resource.TestCheckResourceAttr(resourceName, "license_type", "RHEL_BYOS"),
 					resource.TestCheckResourceAttr(resourceName, "managed_service_identity.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "managed_service_identity.0.resource_group_name", "AutomationResourceGroup"),
 					resource.TestCheckResourceAttr(resourceName, "managed_service_identity.0.name", "AutomationResourceIdentity"),
@@ -227,6 +228,7 @@ func TestAccSpotinstElastigroupAzureV3_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "min_size", "0"),
 					resource.TestCheckResourceAttr(resourceName, "desired_capacity", "0"),
 					resource.TestCheckResourceAttr(resourceName, "os", "Linux"),
+					resource.TestCheckResourceAttr(resourceName, "license_type", "SLES_BYOS"),
 					resource.TestCheckResourceAttr(resourceName, "managed_service_identity.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "managed_service_identity.0.resource_group_name", "AutomationResourceGroup"),
 					resource.TestCheckResourceAttr(resourceName, "managed_service_identity.0.name", "AutomationResourceIdentity"),
@@ -263,6 +265,7 @@ resource "` + string(commons.ElastigroupAzureV3ResourceName) + `" "%v" {
 
  // --- LAUNCHSPEC ----------
  custom_data = "IyEvY=IyEvYmluL2Jhc2gKZWNobyAidGVzdCI="
+ license_type = "RHEL_BYOS"
 
  managed_service_identity {
     resource_group_name = "AutomationResourceGroup"
@@ -303,6 +306,10 @@ resource "` + string(commons.ElastigroupAzureV3ResourceName) + `" "%v" {
  max_size 		  = 5
  min_size 		  = 0
  desired_capacity = 0
+ // -------------------------
+
+ // --- LAUNCHSPEC ----------
+ license_type = "SLES_BYOS"
  // -------------------------
 
  managed_service_identity {

--- a/spotinst/resource_spotinst_ocean_aks_np_test.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_test.go
@@ -235,6 +235,46 @@ func TestAccSpotinstOceanAKSNP_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.0.vm_max_map_count", "79550"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.mode", "Required"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.zone", "."),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.query_logging", "Error"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.protocol", "PreferUDP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.forward_destination", "VnetDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.forward_policy", "Sequential"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.max_concurrent", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.cache_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.serve_stale_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.serve_stale", "Immediate"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.zone", "cluster.local"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.query_logging", "Error"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.protocol", "PreferUDP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.forward_destination", "VnetDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.forward_policy", "Sequential"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.max_concurrent", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.cache_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.serve_stale_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.serve_stale", "Immediate"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.zone", "."),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.query_logging", "Error"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.protocol", "PreferUDP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.forward_destination", "VnetDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.forward_policy", "Sequential"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.max_concurrent", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.cache_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.serve_stale_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.serve_stale", "Immediate"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.zone", "cluster.local"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.query_logging", "Error"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.protocol", "PreferUDP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.forward_destination", "VnetDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.forward_policy", "Sequential"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.max_concurrent", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.cache_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.serve_stale_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.serve_stale", "Immediate"),
 				),
 			},
 			{
@@ -262,6 +302,46 @@ func TestAccSpotinstOceanAKSNP_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.0.vm_max_map_count", "79551"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.mode", "Preferred"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.zone", "."),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.query_logging", "Log"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.protocol", "ForceTCP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.forward_destination", "ClusterCoreDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.forward_policy", "RoundRobin"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.max_concurrent", "1500"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.cache_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.serve_stale_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.serve_stale", "Verify"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.zone", "cluster.local"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.query_logging", "Log"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.protocol", "ForceTCP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.forward_destination", "ClusterCoreDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.forward_policy", "RoundRobin"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.max_concurrent", "1500"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.cache_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.serve_stale_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.serve_stale", "Verify"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.zone", "."),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.query_logging", "Log"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.protocol", "ForceTCP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.forward_destination", "ClusterCoreDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.forward_policy", "RoundRobin"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.max_concurrent", "1500"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.cache_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.serve_stale_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.serve_stale", "Verify"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.zone", "cluster.local"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.query_logging", "Log"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.protocol", "ForceTCP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.forward_destination", "ClusterCoreDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.forward_policy", "RoundRobin"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.max_concurrent", "1500"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.cache_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.serve_stale_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.serve_stale", "Verify"),
 				),
 			},
 		},
@@ -311,6 +391,62 @@ resource "` + string(commons.OceanAKSNPResourceName) + `" "%v" {
   fallback_to_ondemand       = false
   draining_timeout           = 300
   should_utilize_commitments = false
+
+  // ----------------------------------------------------------------------
+
+  // --- Local DNS Profile ---------------------------------------------------------
+
+  local_dns_profile {
+    mode = "Required"
+
+    vnet_dns_overrides {
+      zone                            = "."
+      query_logging                   = "Error"
+      protocol                        = "PreferUDP"
+      forward_destination             = "VnetDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+
+    vnet_dns_overrides {
+      zone                            = "cluster.local"
+      query_logging                   = "Error"
+      protocol                        = "PreferUDP"
+      forward_destination             = "VnetDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+
+    kube_dns_overrides {
+      zone                            = "."
+      query_logging                   = "Error"
+      protocol                        = "PreferUDP"
+      forward_destination             = "VnetDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+
+    kube_dns_overrides {
+      zone                            = "cluster.local"
+      query_logging                   = "Error"
+      protocol                        = "PreferUDP"
+      forward_destination             = "VnetDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+  }
 
   // ----------------------------------------------------------------------
 
@@ -371,6 +507,62 @@ resource "` + string(commons.OceanAKSNPResourceName) + `" "%v" {
   fallback_to_ondemand       = true
   draining_timeout           = 900
   should_utilize_commitments = true
+
+  // ----------------------------------------------------------------------
+
+  // --- Local DNS Profile ---------------------------------------------------------
+  
+local_dns_profile {
+    mode = "Preferred"
+
+    vnet_dns_overrides {
+      zone                            = "."
+      query_logging                   = "Log"
+      protocol                        = "ForceTCP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "RoundRobin"
+      max_concurrent                  = 1500
+      cache_duration_in_seconds       = 4000
+      serve_stale_duration_in_seconds = 4000
+      serve_stale                     = "Verify"
+    }
+
+    vnet_dns_overrides {
+      zone                            = "cluster.local"
+      query_logging                   = "Log"
+      protocol                        = "ForceTCP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "RoundRobin"
+      max_concurrent                  = 1500
+      cache_duration_in_seconds       = 4000
+      serve_stale_duration_in_seconds = 4000
+      serve_stale                     = "Verify"
+    }
+
+    kube_dns_overrides {
+      zone                            = "."
+      query_logging                   = "Log"
+      protocol                        = "ForceTCP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "RoundRobin"
+      max_concurrent                  = 1500
+      cache_duration_in_seconds       = 4000
+      serve_stale_duration_in_seconds = 4000
+      serve_stale                     = "Verify"
+    }
+
+    kube_dns_overrides {
+      zone                            = "cluster.local"
+      query_logging                   = "Log"
+      protocol                        = "ForceTCP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "RoundRobin"
+      max_concurrent                  = 1500
+      cache_duration_in_seconds       = 4000
+      serve_stale_duration_in_seconds = 4000
+      serve_stale                     = "Verify"
+    }
+  }
 
   // ----------------------------------------------------------------------
 

--- a/spotinst/resource_spotinst_ocean_aks_np_test.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_test.go
@@ -219,6 +219,7 @@ func TestAccSpotinstOceanAKSNP_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_count", "100"),
 					resource.TestCheckResourceAttr(resourceName, "max_pods_per_node", "30"),
 					resource.TestCheckResourceAttr(resourceName, "enable_node_public_ip", "true"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_at_host", "true"),
 					resource.TestCheckResourceAttr(resourceName, "os_disk_size_gb", "32"),
 					resource.TestCheckResourceAttr(resourceName, "os_disk_type", "Managed"),
 					resource.TestCheckResourceAttr(resourceName, "os_type", "Linux"),
@@ -290,6 +291,7 @@ func TestAccSpotinstOceanAKSNP_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_count", "150"),
 					resource.TestCheckResourceAttr(resourceName, "max_pods_per_node", "50"),
 					resource.TestCheckResourceAttr(resourceName, "enable_node_public_ip", "true"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_at_host", "false"),
 					resource.TestCheckResourceAttr(resourceName, "os_disk_size_gb", "64"),
 					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.34"),
 					resource.TestCheckResourceAttr(resourceName, "spot_percentage", "100"),
@@ -373,6 +375,7 @@ resource "` + string(commons.OceanAKSNPResourceName) + `" "%v" {
 
   max_pods_per_node     = 30
   enable_node_public_ip = true
+  encryption_at_host    = true
   os_disk_size_gb       = 32
   os_disk_type          = "Managed"
   os_type               = "Linux"
@@ -489,6 +492,7 @@ resource "` + string(commons.OceanAKSNPResourceName) + `" "%v" {
 
   max_pods_per_node     = 50
   enable_node_public_ip = true
+  encryption_at_host    = false
   os_disk_size_gb       = 64
   os_disk_type          = "Managed"
   os_type               = "Linux"

--- a/spotinst/resource_spotinst_ocean_aks_np_test.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_test.go
@@ -233,6 +233,9 @@ func TestAccSpotinstOceanAKSNP_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.0", "1"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.1", "2"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_vm_sizes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_vm_sizes.0", "Standard_D4s_v3"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_vm_sizes.1", "Standard_D8s_v3"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.0.vm_max_map_count", "79550"),
@@ -301,6 +304,8 @@ func TestAccSpotinstOceanAKSNP_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.0", "1"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.1", "2"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.2", "3"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_vm_sizes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_vm_sizes.0", "Standard_D4s_v3"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.0.vm_max_map_count", "79551"),
@@ -458,6 +463,8 @@ resource "` + string(commons.OceanAKSNPResourceName) + `" "%v" {
     "2"
   ]
 
+  preferred_vm_sizes = ["Standard_D4s_v3", "Standard_D8s_v3"]
+
 %v
 %v
 %v
@@ -575,6 +582,8 @@ local_dns_profile {
     "2",
 	"3"
   ]
+
+  preferred_vm_sizes = ["Standard_D4s_v3"]
 
 %v
 %v

--- a/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group_test.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group_test.go
@@ -149,6 +149,46 @@ func TestAccSpotinstOceanAKSNPVirtualNodeGroup_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.0.vm_max_map_count", "79550"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.mode", "Required"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.zone", "."),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.query_logging", "Error"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.protocol", "PreferUDP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.forward_destination", "VnetDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.forward_policy", "Sequential"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.max_concurrent", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.cache_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.serve_stale_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.serve_stale", "Immediate"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.zone", "cluster.local"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.query_logging", "Error"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.protocol", "PreferUDP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.forward_destination", "VnetDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.forward_policy", "Sequential"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.max_concurrent", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.cache_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.serve_stale_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.serve_stale", "Immediate"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.zone", "."),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.query_logging", "Error"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.protocol", "PreferUDP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.forward_destination", "VnetDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.forward_policy", "Sequential"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.max_concurrent", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.cache_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.serve_stale_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.serve_stale", "Immediate"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.zone", "cluster.local"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.query_logging", "Error"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.protocol", "PreferUDP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.forward_destination", "VnetDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.forward_policy", "Sequential"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.max_concurrent", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.cache_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.serve_stale_duration_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.serve_stale", "Immediate"),
 				),
 			},
 			{
@@ -173,6 +213,46 @@ func TestAccSpotinstOceanAKSNPVirtualNodeGroup_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.0.vm_max_map_count", "79551"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.mode", "Preferred"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.zone", "."),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.query_logging", "Log"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.protocol", "ForceTCP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.forward_destination", "ClusterCoreDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.forward_policy", "RoundRobin"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.max_concurrent", "1500"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.cache_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.serve_stale_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.0.serve_stale", "Verify"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.zone", "cluster.local"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.query_logging", "Log"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.protocol", "ForceTCP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.forward_destination", "ClusterCoreDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.forward_policy", "RoundRobin"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.max_concurrent", "1500"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.cache_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.serve_stale_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.vnet_dns_overrides.1.serve_stale", "Verify"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.zone", "."),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.query_logging", "Log"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.protocol", "ForceTCP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.forward_destination", "ClusterCoreDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.forward_policy", "RoundRobin"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.max_concurrent", "1500"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.cache_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.serve_stale_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.0.serve_stale", "Verify"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.zone", "cluster.local"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.query_logging", "Log"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.protocol", "ForceTCP"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.forward_destination", "ClusterCoreDNS"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.forward_policy", "RoundRobin"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.max_concurrent", "1500"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.cache_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.serve_stale_duration_in_seconds", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "local_dns_profile.0.kube_dns_overrides.1.serve_stale", "Verify"),
 				),
 			},
 		},
@@ -221,7 +301,61 @@ resource "` + string(commons.OceanAKSNPVirtualNodeGroupResourceName) + `" "%v" {
   restrict_scale_down        = true
 
   // ---------------------------------------------------------------------------
- 
+  
+// --- Local DNS Profile ---------------------------------------------------------
+
+  local_dns_profile {
+    mode = "Required"
+
+    vnet_dns_overrides {
+      zone                            = "."
+      query_logging                   = "Error"
+      protocol                        = "PreferUDP"
+      forward_destination             = "VnetDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+
+    vnet_dns_overrides {
+      zone                            = "cluster.local"
+      query_logging                   = "Error"
+      protocol                        = "PreferUDP"
+      forward_destination             = "VnetDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+
+    kube_dns_overrides {
+      zone                            = "."
+      query_logging                   = "Error"
+      protocol                        = "PreferUDP"
+      forward_destination             = "VnetDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+
+    kube_dns_overrides {
+      zone                            = "cluster.local"
+      query_logging                   = "Error"
+      protocol                        = "PreferUDP"
+      forward_destination             = "VnetDNS"
+      forward_policy                  = "Sequential"
+      max_concurrent                  = 1000
+      cache_duration_in_seconds       = 3600
+      serve_stale_duration_in_seconds = 3600
+      serve_stale                     = "Immediate"
+    }
+  }
+
 }
 
 `
@@ -269,6 +403,60 @@ resource "` + string(commons.OceanAKSNPVirtualNodeGroupResourceName) + `" "%v" {
   restrict_scale_down        = false
 
   // ---------------------------------------------------------------------------
+
+// --- Local DNS Profile ---------------------------------------------------------
+  
+  local_dns_profile {
+    mode = "Preferred"
+
+    vnet_dns_overrides {
+      zone                            = "."
+      query_logging                   = "Log"
+      protocol                        = "ForceTCP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "RoundRobin"
+      max_concurrent                  = 1500
+      cache_duration_in_seconds       = 4000
+      serve_stale_duration_in_seconds = 4000
+      serve_stale                     = "Verify"
+    }
+
+    vnet_dns_overrides {
+      zone                            = "cluster.local"
+      query_logging                   = "Log"
+      protocol                        = "ForceTCP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "RoundRobin"
+      max_concurrent                  = 1500
+      cache_duration_in_seconds       = 4000
+      serve_stale_duration_in_seconds = 4000
+      serve_stale                     = "Verify"
+    }
+
+    kube_dns_overrides {
+      zone                            = "."
+      query_logging                   = "Log"
+      protocol                        = "ForceTCP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "RoundRobin"
+      max_concurrent                  = 1500
+      cache_duration_in_seconds       = 4000
+      serve_stale_duration_in_seconds = 4000
+      serve_stale                     = "Verify"
+    }
+
+    kube_dns_overrides {
+      zone                            = "cluster.local"
+      query_logging                   = "Log"
+      protocol                        = "ForceTCP"
+      forward_destination             = "ClusterCoreDNS"
+      forward_policy                  = "RoundRobin"
+      max_concurrent                  = 1500
+      cache_duration_in_seconds       = 4000
+      serve_stale_duration_in_seconds = 4000
+      serve_stale                     = "Verify"
+    }
+  }
 
 }
 

--- a/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group_test.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group_test.go
@@ -147,6 +147,9 @@ func TestAccSpotinstOceanAKSNPVirtualNodeGroup_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.0", "1"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.1", "2"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_vm_sizes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_vm_sizes.0", "Standard_D4s_v3"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_vm_sizes.1", "Standard_D8s_v3"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.0.vm_max_map_count", "79550"),
@@ -212,6 +215,8 @@ func TestAccSpotinstOceanAKSNPVirtualNodeGroup_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.0", "1"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.1", "2"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zones.2", "3"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_vm_sizes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_vm_sizes.0", "Standard_D4s_v3"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "linux_os_config.0.sysctls.0.vm_max_map_count", "79551"),
@@ -359,6 +364,8 @@ resource "` + string(commons.OceanAKSNPVirtualNodeGroupResourceName) + `" "%v" {
     }
   }
 
+  preferred_vm_sizes = ["Standard_D4s_v3", "Standard_D8s_v3"]
+
 }
 
 `
@@ -461,6 +468,8 @@ resource "` + string(commons.OceanAKSNPVirtualNodeGroupResourceName) + `" "%v" {
       serve_stale                     = "Verify"
     }
   }
+
+  preferred_vm_sizes = ["Standard_D4s_v3"]
 
 }
 

--- a/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group_test.go
+++ b/spotinst/resource_spotinst_ocean_aks_np_virtual_node_group_test.go
@@ -132,6 +132,7 @@ func TestAccSpotinstOceanAKSNPVirtualNodeGroup_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_count", "100"),
 					resource.TestCheckResourceAttr(resourceName, "max_pods_per_node", "30"),
 					resource.TestCheckResourceAttr(resourceName, "enable_node_public_ip", "true"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_at_host", "true"),
 					resource.TestCheckResourceAttr(resourceName, "os_disk_size_gb", "32"),
 					resource.TestCheckResourceAttr(resourceName, "os_disk_type", "Managed"),
 					resource.TestCheckResourceAttr(resourceName, "os_type", "Linux"),
@@ -200,6 +201,7 @@ func TestAccSpotinstOceanAKSNPVirtualNodeGroup_Baseline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_count", "150"),
 					resource.TestCheckResourceAttr(resourceName, "max_pods_per_node", "50"),
 					resource.TestCheckResourceAttr(resourceName, "enable_node_public_ip", "false"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_at_host", "false"),
 					resource.TestCheckResourceAttr(resourceName, "os_disk_size_gb", "64"),
 					resource.TestCheckResourceAttr(resourceName, "kubernetes_version", "1.31"),
 					resource.TestCheckResourceAttr(resourceName, "spot_percentage", "100"),
@@ -281,6 +283,7 @@ resource "` + string(commons.OceanAKSNPVirtualNodeGroupResourceName) + `" "%v" {
 
   max_pods_per_node     = 30
   enable_node_public_ip = true
+  encryption_at_host    = true
   os_disk_size_gb       = 32
   os_disk_type          = "Managed"
   os_type               = "Linux"
@@ -383,6 +386,7 @@ resource "` + string(commons.OceanAKSNPVirtualNodeGroupResourceName) + `" "%v" {
 
   max_pods_per_node     = 50
   enable_node_public_ip = false
+  encryption_at_host    = false
   os_disk_size_gb       = 64
   os_disk_type          = "Managed"
   os_type               = "Linux"


### PR DESCRIPTION
Added support for CpuPercentile and MemoryPercentile field in RightSizingRule.
Added support for LocalDnsProfile, PreferredVmSizes and EncryptionAtHost fields in Azure Cluster and VNG.
Added support for LicenseType field in Azure Elastigroup.

https://flexera.atlassian.net/browse/SOD-8426
https://flexera.atlassian.net/browse/SOD-8549
https://flexera.atlassian.net/browse/SOD-8628
https://flexera.atlassian.net/browse/SOD-8070
https://flexera.atlassian.net/browse/SOD-8546